### PR TITLE
fix: 장바구니 요청 수정 및 FE 연동

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.12" />
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />

--- a/CrossFit ERD.sql
+++ b/CrossFit ERD.sql
@@ -281,13 +281,119 @@ ALTER TABLE SAVINGSPRODUCT AUTO_INCREMENT = 1;
 DELETE FROM SAVINGPRODUCTRATES;
 ALTER TABLE SAVINGPRODUCTRATES auto_increment = 1;
 
-CREATE INDEX idx_portfolio_id ON portfolio(portfolioID);
+# start here
 
-ALTER TABLE `portfolioitem`
-    ADD CONSTRAINT `FK_Portfolio_TO_PortfolioItem_1`
-    FOREIGN KEY (`portfolioID`)
-    REFERENCES `portfolio` (`portfolioID`)
-    ON DELETE CASCADE;
+DROP DATABASE CROSS_FIT;
+
+CREATE DATABASE CROSS_FIT;
+
+USE CROSS_FIT;
+
+CREATE TABLE PRODUCT (
+                         productID INT auto_increment primary KEY,
+                         productType CHAR(1) NOT NULL
+);
+
+CREATE TABLE SavingsProduct(
+                               productID INT PRIMARY KEY,
+                               fin_co_no VARCHAR(50),
+                               fin_prdt_cd VARCHAR(50),
+                               kor_co_nm VARCHAR(100),
+                               fin_prdt_nm VARCHAR(100),
+                               dcls_month VARCHAR(6),
+                               join_way TEXT,
+                               mtrt_int TEXT,
+                               spcl_cnd TEXT,
+                               join_deny INT,
+                               join_member VARCHAR(100),
+                               etc_note TEXT,
+                               max_limit VARCHAR(255),
+                               dcls_strt_day VARCHAR(8),
+                               dcls_end_day VARCHAR(8),
+                               RiskLevel INT,
+                               hit INT DEFAULT 0,
+                               FOREIGN KEY (ProductID) REFERENCES Product(ProductID)
+);
+
+CREATE TABLE SavingProductRates (
+                                    productID INT,
+                                    save_trm INT,
+                                    intr_rate_type CHAR(1),
+                                    intr_rate_type_nm VARCHAR(20),
+                                    intr_rate DECIMAL(5,2),
+                                    intr_rate2 DECIMAL(5,2),
+                                    rsrv_type VARCHAR(10),
+                                    rsrv_type_nm VARCHAR(50),
+                                    PRIMARY KEY (productID, save_trm, rsrv_type),
+                                    FOREIGN KEY (productID) REFERENCES SavingsProduct(productID)
+);
+
+CREATE TABLE FundProduct (
+                             productID INT NOT NULL,               -- 금융상품 테이블의 외래키
+                             company_nm VARCHAR(100),            -- 운용사명
+                             product_nm VARCHAR(255),             -- 상품명
+                             yield_1 DECIMAL(15,2),                -- 1개월 누적수익률
+                             yield_3 DECIMAL(15,2),                -- 3개월 누적수익률
+                             yield_6 DECIMAL(15,2),                -- 6개월 누적수익률
+                             yield_12 DECIMAL(15,2),               -- 12개월 누적수익률
+                             RiskLevel INT,                        -- 펀드 등급
+                             fund_type VARCHAR(50),                         -- 펀드 유형
+                             advanced_fee DECIMAL(15,2),           -- 선취수수료
+                             total_payoff_rate DECIMAL(15,2),      -- 총 보수율
+                             hit INT,                              -- 조회수
+                             PRIMARY KEY (ProductID),              -- Primary Key 설정
+                             FOREIGN KEY (ProductID) REFERENCES Product(ProductID) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE BondProduct (
+                             productID INT NOT NULL,                -- 상품ID (Product 테이블의 외래키)
+                             basDt VARCHAR(8),                     -- 기준일자
+                             crno VARCHAR(13),                      -- 법인등록번호
+                             scrsItmsKcd VARCHAR(4),               -- 유가증권종목코드
+                             isinCd VARCHAR(12),                    -- ISIN코드
+                             scrsItmsKcdNm VARCHAR(50),             -- 유가증권종목코드명
+                             bondIsurNm VARCHAR(100),               -- 채권발행인명
+                             isinCdNm VARCHAR(100),                 -- ISIN코드명
+                             bondIssuDt VARCHAR(8),                -- 채권발행일자
+                             bondIssuAmt BIGINT,                    -- 채권발행금액
+                             bondIssuCurCd VARCHAR(3),              -- 채권발행통화코드
+                             bondIssuCurCdNm VARCHAR(50),           -- 채권발행통화코드명
+                             bondExprDt VARCHAR(8),                -- 채권만기일자
+                             bondPymtAmt BIGINT,                    -- 채권납입금액
+                             irtChngDcd CHAR(1),                    -- 금리변동구분코드
+                             irtChngDcdNm VARCHAR(50),              -- 금리변동구분코드명
+                             bondSrfcInrt DECIMAL(5, 2),           -- 채권금리
+                             bondIntTcd CHAR(1),                    -- 채권이자형구분코드
+                             bondIntTcdNm VARCHAR(50),              -- 채권이자형구분코드명
+                             intPayCyclCtt VARCHAR(50),             -- 이자지급주기내용
+                             nxtmCopnDt VARCHAR(8),                -- 차기표일자
+                             rbVopnDt VARCHAR(8),                  -- 직전이표일자
+                             kbpScrsItmsKcdNm VARCHAR(100),         -- 한국신용평가유가증권종목종류코드명
+                             niceScrsItmsKcdNm VARCHAR(100),        -- NICE평가정보유가증권종목종류코드명
+                             fnScrsItmsKcdNm VARCHAR(100),          -- FN유가증권종목종류코드명
+                             riskLevel INT,                         -- 위험도
+                             hit INT DEFAULT 0,                     -- 조회수, 기본값 0
+                             PRIMARY KEY (productID),               -- Primary Key 설정
+                             FOREIGN KEY (productID) REFERENCES Product(productID) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+select * from product LIMIT 2000;
+select * from savingsProduct;
+select * from savingproductrates;
+select * from fundproduct;
+select * from bondproduct;
+
+
+-- 실패시 밑에서 부터 테이블 삭제하고 다시 시작하셔야합니다!
+DELETE FROM product;  -- 테이블에서 모든 데이터를 삭제
+ALTER TABLE product AUTO_INCREMENT = 1;
+
+DELETE FROM SAVINGSPRODUCT;
+ALTER TABLE SAVINGSPRODUCT AUTO_INCREMENT = 1;
+
+DELETE FROM SAVINGPRODUCTRATES;
+ALTER TABLE SAVINGPRODUCTRATES auto_increment = 1;
+
 
 CREATE TABLE `Portfolio` (
                              `portfolioID` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
@@ -311,10 +417,52 @@ CREATE TABLE `PortfolioItem` (
 CREATE TABLE `CartItem` (
                             `cartID`	INT	NOT NULL AUTO_INCREMENT PRIMARY KEY,
                             `productID`	INT	NOT NULL,
-                            `userNum`	INT	NOT NULL,
+                            `memberNum`	BIGINT UNSIGNED	NOT NULL,
                             `productType` CHAR(1) NOT NULL,
                             `provider` VARCHAR(100) NOT NULL,
                             `productName` VARCHAR(100) NOT NULL,
                             `expectedReturn` DECIMAL(5,2) NULL,
                             `interestRate` DECIMAL(5,2) NULL
+);
+
+CREATE INDEX idx_portfolio_id ON portfolio(portfolioID);
+
+ALTER TABLE `portfolioitem`
+    ADD CONSTRAINT `FK_Portfolio_TO_PortfolioItem_1`
+        FOREIGN KEY (`portfolioID`)
+            REFERENCES `portfolio` (`portfolioID`)
+            ON DELETE CASCADE;
+
+use cross_fit;
+CREATE TABLE `stock` (
+                         `stockCode` VARCHAR(10) NOT NULL,          -- 주식 코드
+                         `stockName` VARCHAR(50) NULL,              -- 주식 이름
+                         `dailyPrice` DECIMAL(10,2) NULL,           -- 일일 가격
+                         `field` INT NULL,                          -- 분야 코드
+                         `itmsNm` VARCHAR(50) NULL,                 -- 항목 이름
+                         `mrktCtg` VARCHAR(50) NULL,                -- 시장 카테고리
+                         `clpr` INT NULL,                           -- 종가
+                         `vs` INT NULL,                             -- 등락폭
+                         `fltRt` DECIMAL(5,2) NULL,                 -- 등락률
+                         `mkp` INT NULL,                            -- 시가
+                         `hipr` INT NULL,                           -- 최고가
+                         `lopr` INT NULL,                           -- 최저가
+                         `trqu` BIGINT NULL,                        -- 거래량
+                         `trPrc` BIGINT NULL,                       -- 거래대금
+                         `istgStCnt` BIGINT NULL,                   -- 상장 주식 수
+                         `mrktTotAmt` BIGINT NULL,                  -- 시장 총액
+                         PRIMARY KEY (`stockCode`)                  -- stockCode를 기본 키로 설정
+);
+
+CREATE TABLE `Member` (
+                          `member_num`	BIGINT UNSIGNED	NOT NULL auto_increment primary key,
+                          `member_id` varchar(100) NOT NULL unique,
+                          `member_name`	VARCHAR(50)	NOT NULL,
+                          `email` VARCHAR(100) NOT NULL unique,
+                          `password`	VARCHAR(255) NOT NULL,
+                          `birth`	DATE	NULL,
+                          `preference`	INT	NULL,
+                          `invest_score`	INT	NULL,
+                          `reg_Date`	DATETIME NULL,
+                          `gender`	VARCHAR(10)	NULL
 );

--- a/src/main/java/com/be/auth/config/SecurityConfig.java
+++ b/src/main/java/com/be/auth/config/SecurityConfig.java
@@ -47,8 +47,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .antMatchers(HttpMethod.GET,"/**", "/home").permitAll()
-                .antMatchers(HttpMethod.POST, "/api/member/login", "/api/member/register")
-                .permitAll()
+                .antMatchers(HttpMethod.POST, "/api/member/login", "/api/member/register").permitAll()
+//                 테스트
+                .antMatchers(HttpMethod.POST, "/api/cart", "/api/portfolio/**").permitAll()
+                .antMatchers(HttpMethod.DELETE, "/api/cart/**", "/api/portfolio/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/be/cart/domain/CartItemVO.java
+++ b/src/main/java/com/be/cart/domain/CartItemVO.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class CartItemVO {
     private int cartId;
     private int productId;
-    private int userNum;
+    private long memberNum;
     private String productType;
     private String provider;
     private String productName;

--- a/src/main/java/com/be/cart/domain/CartList.java
+++ b/src/main/java/com/be/cart/domain/CartList.java
@@ -7,7 +7,7 @@ import java.util.List;
 @Data
 public class CartList {
     private List<CartItemVO> cartItems;
-    private int userNum;
+    private Long memberNum;
     private int totalCount;
 
 }

--- a/src/main/java/com/be/cart/dto/req/CartItemReqDto.java
+++ b/src/main/java/com/be/cart/dto/req/CartItemReqDto.java
@@ -1,7 +1,9 @@
 package com.be.cart.dto.req;
 
 import com.be.cart.domain.CartItemVO;
+import com.be.cart.dto.res.CartItemResDto;
 import com.be.portfolio.domain.PortfolioItemVO;
+import com.be.portfolio.dto.req.PortfolioItemReqDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,8 +14,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class CartItemReqDto {
+    private int cartId;
     private int productId;
-    private int userNum;
+    private long memberNum;
     private String productType;
     private String provider;
     private String productName;
@@ -23,7 +26,7 @@ public class CartItemReqDto {
     public CartItemVO toVO() {
         return CartItemVO.builder()
                 .productId(productId)
-                .userNum(userNum)
+                .memberNum(memberNum)
                 .productType(productType)
                 .provider(provider)
                 .productName(productName)

--- a/src/main/java/com/be/cart/dto/res/CartItemResDto.java
+++ b/src/main/java/com/be/cart/dto/res/CartItemResDto.java
@@ -1,6 +1,7 @@
 package com.be.cart.dto.res;
 
 import com.be.cart.domain.CartItemVO;
+import com.be.cart.dto.req.CartItemReqDto;
 import com.be.portfolio.domain.PortfolioItemVO;
 import com.be.portfolio.dto.res.PortfolioItemResDto;
 import lombok.AllArgsConstructor;
@@ -15,18 +16,31 @@ import lombok.NoArgsConstructor;
 public class CartItemResDto {
     private int cartId;
     private int productId;
-    private int userNum;
+    private long memberNum;
     private String productType;
     private String provider;
     private String productName;
     private Double expectedReturn;
     private Double interestRate;
 
+    public static CartItemResDto of(CartItemReqDto reqDto) {
+        return reqDto == null ? null : CartItemResDto.builder()
+                .cartId(reqDto.getCartId())
+                .productId(reqDto.getProductId())
+                .memberNum(reqDto.getMemberNum())
+                .productType(reqDto.getProductType())
+                .provider(reqDto.getProvider())
+                .productName(reqDto.getProductName())
+                .expectedReturn(reqDto.getExpectedReturn())
+                .interestRate(reqDto.getInterestRate())
+                .build();
+    }
+
     public static CartItemResDto of(CartItemVO cartVO) {
         return cartVO == null ? null : CartItemResDto.builder()
                 .cartId(cartVO.getCartId())
                 .productId(cartVO.getProductId())
-                .userNum(cartVO.getUserNum())
+                .memberNum(cartVO.getMemberNum())
                 .productType(cartVO.getProductType())
                 .provider(cartVO.getProvider())
                 .productName(cartVO.getProductName())
@@ -39,7 +53,7 @@ public class CartItemResDto {
         return CartItemVO.builder()
                 .cartId(cartItemResDto.getCartId())
                 .productId(cartItemResDto.getProductId())
-                .userNum(cartItemResDto.getUserNum())
+                .memberNum(cartItemResDto.getMemberNum())
                 .productType(cartItemResDto.getProductType())
                 .provider(cartItemResDto.getProvider())
                 .productName(cartItemResDto.getProductName())

--- a/src/main/java/com/be/cart/mapper/CartMapper.java
+++ b/src/main/java/com/be/cart/mapper/CartMapper.java
@@ -6,8 +6,8 @@ import org.apache.ibatis.annotations.Param;
 import java.util.List;
 
 public interface CartMapper {
-    List<CartItemVO> getCartItemList(int userNum);
-    CartItemVO checkCartItem(@Param("userNum") int userNum, @Param("productId") int productId);
+    List<CartItemVO> getCartItemList(long memberNum);
+    CartItemVO checkCartItem(@Param("memberNum") long memberNum, @Param("productId") int productId);
     int addCartItem(CartItemVO cartVO);
     void deleteCartItem(int cartId);
 }

--- a/src/main/java/com/be/cart/service/CartService.java
+++ b/src/main/java/com/be/cart/service/CartService.java
@@ -6,7 +6,7 @@ import com.be.cart.dto.res.CartItemResDto;
 import java.util.List;
 
 public interface CartService {
-    List<CartItemResDto> getCartList(int userNum);
+    List<CartItemResDto> getCartList(long memberNum);
     CartItemResDto addCartItem(CartItemReqDto cart);
     void deleteCartItem(int cartId);
     boolean checkCartItem(CartItemReqDto cart);

--- a/src/main/java/com/be/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/be/cart/service/CartServiceImpl.java
@@ -15,8 +15,8 @@ public class CartServiceImpl implements CartService {
     private final CartMapper cartMapper;
 
     @Override
-    public List<CartItemResDto> getCartList(int userNum) {
-        return cartMapper.getCartItemList(userNum)
+    public List<CartItemResDto> getCartList(long memberNum) {
+        return cartMapper.getCartItemList(memberNum)
                 .stream().map(CartItemResDto::of).toList();
     }
 
@@ -38,7 +38,7 @@ public class CartServiceImpl implements CartService {
 
     @Override
     public boolean checkCartItem(CartItemReqDto cart) {
-        if(cartMapper.checkCartItem(cart.getUserNum(), cart.getProductId()) == null) return false;
+        if(cartMapper.checkCartItem(cart.getMemberNum(), cart.getProductId()) == null) return false;
         return true;
     }
 }

--- a/src/main/java/com/be/common/pagination/Page.java
+++ b/src/main/java/com/be/common/pagination/Page.java
@@ -1,0 +1,26 @@
+package com.be.common.pagination;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Page<T> {
+    private int totalCount; // 전체 데이터 건수
+    private int totalPage; // 전체 페이지 수
+    @JsonIgnore
+    private PageRequest pageRequest;
+    private List<T> list; // 데이터 목록
+    public static <T> Page of(PageRequest pageRequest, int totalCount, List<T> list) {
+        int totalPage = (int)Math.ceil((double)totalCount / pageRequest.getAmount()); // 전체 페이지 수 계산
+        return new Page(totalCount, totalPage, pageRequest, list);
+    }
+    public int getPageNum() { return pageRequest.getPage(); }
+    public int getAmount() { return pageRequest.getAmount(); }
+}

--- a/src/main/java/com/be/common/pagination/PageRequest.java
+++ b/src/main/java/com/be/common/pagination/PageRequest.java
@@ -1,0 +1,28 @@
+package com.be.common.pagination;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // private 레벨의 생성자(외부에서 접근 불가) -> 팩토리 메서드로 사용
+public class PageRequest {
+    private int page; // 요청 페이지
+    private int amount; //한 페이지 당 데이터 건수
+
+    // 기본 생성자에서 기본 페이지 1개, 기본 데이터 10개로 초기화
+    public PageRequest() {
+        page = 1;
+        amount = 10;
+    }
+
+    // 팩토리 메소드를 사용해서 PageRequest 생성자 사용
+    public static PageRequest of(int page, int amount) {
+        return new PageRequest(page, amount);
+    }
+
+
+    public int getOffset() { // offset 값 계산
+        return (page - 1) * amount;
+    }
+}

--- a/src/main/java/com/be/config/RootConfig.java
+++ b/src/main/java/com/be/config/RootConfig.java
@@ -27,11 +27,12 @@ import javax.sql.DataSource;
         "com.be.portfolio.mapper",
         "com.be.finance.mapper",
         "com.be.cart.mapper",
+        "com.be.cart.mapper",
         "com.be.member.mapper"
 })
 @ComponentScan(basePackages = {
         "com.be.portfolio.service",
-        "com.be.cart.service"
+        "com.be.cart.service",
 })
 @Slf4j
 @EnableTransactionManagement

--- a/src/main/java/com/be/finance/controller/FundProductController.java
+++ b/src/main/java/com/be/finance/controller/FundProductController.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/src/main/java/com/be/finance/service/BondProductService.java
+++ b/src/main/java/com/be/finance/service/BondProductService.java
@@ -41,7 +41,7 @@ public class BondProductService {
 
     public void fetchAndSaveBondProducts() {
         // 요청 URL
-        String url = bondProductApiUrl + "?serviceKey=" + bondAuthKey + "&numOfRows=30&pageNo=3&resultType=json";
+        String url = bondProductApiUrl + "?serviceKey=" + bondAuthKey + "&numOfRows=30&pageNo=30&resultType=json";
         System.out.println(url);
 
         // OkHttp 요청 구성

--- a/src/main/java/com/be/member/dto/req/MemberLoginReqDto.java
+++ b/src/main/java/com/be/member/dto/req/MemberLoginReqDto.java
@@ -13,8 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 @NoArgsConstructor
 public class MemberLoginReqDto {
-
     private String memberID;
     private String password;
-
 }

--- a/src/main/java/com/be/portfolio/controller/PortfolioController.java
+++ b/src/main/java/com/be/portfolio/controller/PortfolioController.java
@@ -1,32 +1,35 @@
 package com.be.portfolio.controller;
 
-//import com.be.cart.service.CartService;
+import com.be.cart.dto.res.CartItemResDto;
+import com.be.cart.service.CartService;
 import com.be.finance.service.FinanceService;
-import com.be.portfolio.domain.PortfolioVO;
 import com.be.portfolio.dto.req.PortfolioItemReqDto;
 import com.be.portfolio.dto.req.PortfolioReqDto;
 import com.be.portfolio.dto.res.PortfolioResDto;
 import com.be.portfolio.service.PortfolioService;
 import com.be.stock.service.StockService;
 import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/portfolio")
 @RequiredArgsConstructor
 public class PortfolioController {
     private final PortfolioService portfolioService;
-//    private final CartService cartService;
+    private final CartService cartService;
     private final StockService stockService;
     private final FinanceService financeService;
 
-//    @GetMapping("/{userNum}")
-//    public ResponseEntity<List<CartItemResDto>> getCartItems(@PathVariable Integer userNum) {
-//        return ResponseEntity.ok(cartService.getCartList(userNum));
-//    }
+    @GetMapping("/{userNum}")
+    public ResponseEntity<List<CartItemResDto>> getCartItems(@PathVariable Integer userNum) {
+        return ResponseEntity.ok(cartService.getCartList(userNum));
+    }
 
 //    @GetMapping
 //    public ResponseEntity<List<FinanceResDto>> getFinanceProduct(@RequestParam String query) {
@@ -40,7 +43,44 @@ public class PortfolioController {
 
     @PostMapping
     public ResponseEntity<PortfolioResDto> createPortfolio(PortfolioReqDto portfolioReqDto, List<PortfolioItemReqDto> portfolioItems) {
-        return ResponseEntity.ok(portfolioService.createPortfolio(portfolioReqDto, portfolioItems));
+//        JSONObject stockPrices = new JSONObject();
+//        List<JSONObject> jsonObjects = new ArrayList<>();
+//        for (PortfolioItemReqDto portfolioItemReqDto : portfolioItems) {
+//            if(!portfolioItemReqDto.getStockCode().isEmpty()) {
+//                JSONObject stockJson = stockService.getStockData(portfolioItemReqDto.getStockCode());
+//                jsonObjects.add(stockJson);
+//            }
+//        }
+//
+//        for (JSONObject obj : jsonObjects) {
+//            Iterator it = obj.keySet().iterator();
+//            while (it.hasNext()) {
+//                String key = (String)it.next();
+//                stockPrices.put(key, obj.get(key));
+//            }
+//        }
+
+        /* 비동기식 호출 */
+        JSONObject stockPrices = new JSONObject();
+
+        // CompletableFuture 리스트 생성
+        List<CompletableFuture<JSONObject>> futures = portfolioItems.stream()
+                .filter(item -> !item.getStockCode().isEmpty())
+                .map(item -> CompletableFuture.supplyAsync(() -> stockService.getStockData(item.getStockCode())))
+                .collect(Collectors.toList());
+
+        // CompletableFuture 배열을 모두 완료하고 결과를 합침
+        CompletableFuture<Void> allOf = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        allOf.thenAccept(voidResult -> {
+            for (CompletableFuture<JSONObject> future : futures) {
+                JSONObject obj = future.join(); // CompletableFuture가 완료될 때까지 대기하고 결과를 가져옴
+                if (obj != null) {
+                    obj.keySet().forEach(key -> stockPrices.put(key, obj.get(key)));
+                }
+            }
+        }).join(); // CompletableFuture의 완료를 기다림
+
+        return ResponseEntity.ok(portfolioService.createPortfolio(portfolioReqDto, portfolioItems, stockPrices));
     }
 
     @GetMapping("/{portfolioID}")
@@ -52,9 +92,5 @@ public class PortfolioController {
     public ResponseEntity<PortfolioResDto> deletePortfolio(@PathVariable Integer portfolioID) {
         return ResponseEntity.ok(portfolioService.deletePortfolio(portfolioID));
     }
-
-    // 전략 패턴 선택?
-
-    // 튜토리얼?
 }
 

--- a/src/main/java/com/be/portfolio/dto/req/PortfolioItemReqDto.java
+++ b/src/main/java/com/be/portfolio/dto/req/PortfolioItemReqDto.java
@@ -19,16 +19,6 @@ public class PortfolioItemReqDto {
     private int amount;
     private double expectedReturn;
 
-    public PortfolioItemReqDto of(PortfolioItemVO vo) {
-        return vo == null ? null : PortfolioItemReqDto.builder()
-                .portfolioId(vo.getPortfolioId())
-                .productId(vo.getProductId())
-                .stockCode(vo.getStockCode())
-                .amount(vo.getAmount())
-                .expectedReturn(vo.getExpectedReturn())
-                .build();
-    }
-
     public static PortfolioItemReqDto of(PortfolioItemResDto resDto) {
         return resDto == null ? null : PortfolioItemReqDto.builder()
                 .portfolioId(resDto.getPortfolioId())

--- a/src/main/java/com/be/portfolio/dto/req/PortfolioReqDto.java
+++ b/src/main/java/com/be/portfolio/dto/req/PortfolioReqDto.java
@@ -26,17 +26,6 @@ public class PortfolioReqDto {
 
     private List<PortfolioItemReqDto> portfolioItems = new ArrayList<>();
 
-    public PortfolioReqDto of(PortfolioVO vo) {
-        return vo == null ? null : PortfolioReqDto.builder()
-                .creationDate(vo.getCreationDate())
-                .total(vo.getTotal())
-                .expectedReturn(vo.getExpectedReturn())
-                .riskLevel(vo.getRiskLevel())
-                .portfolioName(vo.getPortfolioName())
-                .userNum(vo.getUserNum())
-                .build();
-    }
-
     public static PortfolioReqDto of(PortfolioResDto resDto) {
         return resDto == null ? null : PortfolioReqDto.builder()
                 .creationDate(resDto.getCreationDate())

--- a/src/main/java/com/be/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/be/portfolio/service/PortfolioService.java
@@ -7,6 +7,8 @@ import com.be.portfolio.dto.req.PortfolioReqDto;
 import com.be.portfolio.dto.res.PortfolioItemResDto;
 import com.be.portfolio.dto.res.PortfolioPortionDto;
 import com.be.portfolio.dto.res.PortfolioResDto;
+import com.be.stock.service.StockService;
+import org.json.JSONObject;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.List;
@@ -14,13 +16,13 @@ import java.util.List;
 public interface PortfolioService {
     PortfolioResDto getPortfolio(int portfolioId);
     List<PortfolioItemResDto> getPortfolioItems(int portfolioId);
-    PortfolioResDto createPortfolio(PortfolioReqDto portfolioReqDto, List<PortfolioItemReqDto> portfolioItems);
+    PortfolioResDto createPortfolio(PortfolioReqDto portfolioReqDto, List<PortfolioItemReqDto> portfolioItems, JSONObject stockPrices);
     PortfolioResDto updatePortfolio(PortfolioVO portfolioVO);
 
     @Scheduled(cron = "0 0 0 * * ?")
     void updateAllPortfolio();
 
     PortfolioResDto deletePortfolio(int id);
-    PortfolioReqDto calculatePortfolio(PortfolioReqDto portfolioReqDto);
+    PortfolioReqDto calculatePortfolio(PortfolioReqDto portfolioReqDto, JSONObject stockPrices);
     PortfolioPortionDto calculatePortion(List<PortfolioItemResDto> portfolioItems);
 }

--- a/src/main/java/com/be/portfolio/service/calcultate.py
+++ b/src/main/java/com/be/portfolio/service/calcultate.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import FinanceDataReader as fdr
+
+from pypfopt.expected_returns import mean_historical_return
+from pypfopt.risk_models import CovarianceShrinkage
+from pypfopt.efficient_frontier import EfficientFrontier
+
+stock_list = [
+    ["삼성전자","005930"],
+    ["SK하이닉스", "000660"],
+    ["기아", "000270"],
+    ["카카오", "035720"],
+    ["KB금융그룹", "105560"]
+]
+df_list=[fdr.DataReader(code[1], '2023', '2024')['Close'] for code in stock_list]
+df = pd.concat(df_list, axis=1)
+df.columns = [name for name, code in stock_list]
+df.head(10)
+
+mu = mean_historical_return(df);
+S = CovarianceShrinkage(df).ledoit_wolf()
+
+ef = EfficientFrontier(mu, S)
+weights = ef.max_sharpe()
+print(weights)
+cleaned_weights = ef.clean_weights()
+print(cleaned_weights)
+
+performance = ef.portfolio_performance()
+print(performance)
+
+
+
+

--- a/src/main/java/com/be/portfolio/service/test.py
+++ b/src/main/java/com/be/portfolio/service/test.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import FinanceDataReader as fdr
+
+from pypfopt.expected_returns import mean_historical_return
+from pypfopt.risk_models import CovarianceShrinkage
+from pypfopt.efficient_frontier import EfficientFrontier
+
+stock_list = [
+    ["삼성전자","005930"],
+    ["SK하이닉스", "000660"],
+    ["기아", "000270"],
+    ["카카오", "035720"],
+    ["KB금융그룹", "105560"]
+]
+df_list=[fdr.DataReader(code[1], '2023', '2024')['Close'] for code in stock_list]
+df = pd.concat(df_list, axis=1)
+df.columns = [name for name, code in stock_list]
+df.head(10)
+
+mu = mean_historical_return(df);
+S = CovarianceShrinkage(df).ledoit_wolf()
+
+ef = EfficientFrontier(mu, S)
+weights = ef.max_sharpe()
+print(weights)
+cleaned_weights = ef.clean_weights()
+print(cleaned_weights)
+
+performance = ef.portfolio_performance()
+print(performance)
+

--- a/src/main/java/com/be/recentView/controller/RecentViewController.java
+++ b/src/main/java/com/be/recentView/controller/RecentViewController.java
@@ -1,0 +1,73 @@
+package com.be.recentView.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.util.*;
+
+@RestController
+@RequestMapping("/api/recentView")
+@RequiredArgsConstructor
+public class RecentViewController {
+    @GetMapping
+    public List<String> getRecentViewedItems(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        List<String> productIds = new ArrayList<>();
+        StringBuilder recentProducts = new StringBuilder();
+
+        if(cookies != null) {
+            for(Cookie cookie : cookies) {
+                if(cookie.getName().equals("recentViewedItems")) {
+                    recentProducts.append(cookie.getValue());
+                    break;
+                }
+            }
+            // 뒤에서부터 최근에 본 목록
+            productIds = Arrays.asList(recentProducts.toString().split(","));
+        }
+
+        return productIds;
+    }
+
+    @GetMapping("/do") /* -> 쿠키 생성(상품 조회시 ~ financeController로 이동) */
+    public void getRecentViewedItem(HttpServletRequest request, HttpServletResponse response, String productId) {
+//        Cookie cookie = new Cookie("recentViewedItem" + Id, String.valueOf(productId));
+//        cookie.setPath("/");
+//        cookie.setMaxAge(60 * 60 * 24);
+//        response.addCookie(cookie);
+        Cookie[] cookies = request.getCookies();
+        StringBuilder recentProducts = new StringBuilder();
+
+        if(cookies == null) {
+            Cookie cookie = new Cookie("recentViewedItems", productId);
+            return;
+        } else {
+            for(Cookie cookie : cookies) {
+                if(cookie.getName().equals("recentViewedItems")) {
+                    recentProducts.append(cookie.getValue());
+                    break;
+                }
+            }
+            if(recentProducts.isEmpty()) {
+                Cookie cookie = new Cookie("recentViewedItems", productId);
+                return;
+            }
+        }
+
+        List<String> productIds = Arrays.asList(recentProducts.toString().split(","));
+        // 최근 본 상품 5개만 유지
+        if(productIds.size() > 5) {
+            productIds.remove(0);
+        }
+
+        // 쿠키 업데이트
+        Cookie recentProductsCookie = new Cookie("recentProducts", String.join(",", productIds));
+        recentProductsCookie.setMaxAge(60 * 60 * 24); // 쿠키의 유효기간 설정 (1일)
+        response.addCookie(recentProductsCookie);
+    }
+}

--- a/src/main/java/com/be/stock/controller/StockController.java
+++ b/src/main/java/com/be/stock/controller/StockController.java
@@ -2,6 +2,7 @@ package com.be.stock.controller;
 
 import com.be.stock.domain.StockVO;
 import com.be.stock.service.StockService;
+import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,5 +37,11 @@ public class StockController {
         // 주식 데이터를 검색해서 반환
         return stockService.searchStock(searchTerm);
 
+    }
+
+    @GetMapping("/data")
+    public JSONObject searchStock() {
+        // DB에서 검색어에 맞는 주식 데이터를 조회하여 JSON으로 반환
+        return stockService.getStockData("005930");
     }
 }

--- a/src/main/resources/mapper/CartMapper.xml
+++ b/src/main/resources/mapper/CartMapper.xml
@@ -8,20 +8,20 @@
     <resultMap id="cartItemMap" type="com.be.cart.domain.CartItemVO">
         <id column="cartID" property="cartId"/>
         <result column="productID" property="productId"/>
-        <result column="userNum" property="userNum"/>
+        <result column="memberNum" property="memberNum"/>
     </resultMap>
 
     <select id="getCartItemList" resultType="com.be.cart.domain.CartItemVO">
-        select c.cartID, c.productID, c.userNum from cartitem c
-        where userNum = #{userNum}
+        select cartID, productID, memberNum, productType, provider, productName, expectedReturn, interestRate from cartitem
+        where memberNum = #{memberNum}
     </select>
     <select id="checkCartItem" resultType="com.be.cart.domain.CartItemVO">
         select * from cartitem
-        where productID = #{productId} and userNum = #{userNum}
+        where productID = #{productId} and memberNum = #{memberNum}
     </select>
     <insert id="addCartItem">
-        insert into cartitem (productID, userNum, productType, provider, productName, expectedReturn, interestRate)
-        values (#{productId}, #{userNum}, #{productType}, #{provider}, #{productName}, #{expectedReturn}, #{interestRate})
+        insert into cartitem (productID, memberNum, productType, provider, productName, expectedReturn, interestRate)
+        values (#{productId}, #{memberNum}, #{productType}, #{provider}, #{productName}, #{expectedReturn}, #{interestRate})
 
         <selectKey resultType="Int" keyProperty="cartId" keyColumn="cartID" order="AFTER">
             SELECT LAST_INSERT_ID()

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -39,7 +39,13 @@
   <button type="submit">Submit</button>
   </form>
 
+<form action="/api/stock/fetch" method="get">
+  <button type="submit">주식 DB 추가하기</button>
+</form>
 
+<form action="/api/stock/data" method="get">
+  <button type="submit">주식 json 추출</button>
+</form>
 
 <h3>주식 검색</h3>
 <!-- 검색 폼: 서버로 검색어를 전송 -->

--- a/src/test/java/com/be/portfolio/service/PortfolioServiceImplTest.java
+++ b/src/test/java/com/be/portfolio/service/PortfolioServiceImplTest.java
@@ -9,13 +9,21 @@ import com.be.portfolio.dto.res.PortfolioPortionDto;
 import com.be.portfolio.dto.res.PortfolioResDto;
 import com.be.portfolio.mapper.PortfolioMapper;
 import lombok.extern.log4j.Log4j;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URLEncoder;
+import java.nio.file.Paths;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
@@ -26,6 +34,8 @@ public class PortfolioServiceImplTest {
 
     @Autowired
     PortfolioMapper portfolioMapper;
+
+
 
     @Test
     public void testGetPortfolio() {
@@ -98,6 +108,30 @@ public class PortfolioServiceImplTest {
     @Test
     void calculatePortfolio() {
 
+        try {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("005930", new int[]{79600,77000,76600,76600,76500,74700,73600,73200,73100,73900,72600,71000,71700,74700,75100,75200,74000});
+
+            //            String strJson = "{\"005930\":[79600,77000,76600,76600,76500,74700,73600,73200,73100,73900,72600,71000,71700,74700,75100,75200,74000]}";
+
+            ProcessBuilder processBuilder = new ProcessBuilder("python", "src/main/java/com/be/portfolio/service/test.py", jsonObject.toString());
+            Process process = processBuilder.start();
+
+            InputStream inputStream = process.getInputStream();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+
+            String line;
+            while((line = reader.readLine()) != null) {
+                System.out.println(line);
+            }
+
+            // 파이썬 플라스크 서버 연결 + 계산 + 반환
+            // portfolio의 expectedReturn, riskLevel, portfolioItem의 expectedReturn 반환
+
+            //
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Test


### PR DESCRIPTION
1. 장바구니 FE와 연동되게 수정했습니다.
* login 요청에 장바구니 DB 호출 및 세션 저장 추가
* post/delete 요청시 header로 refresh 토큰 넘겨도 401에러 발생해서 임시로 securityConfig 쪽에 permitAll 설정 코드 추가했습니다.
* cart 테이블에 추가할 테스트용 더미 데이터 sql 노션 백엔드 탭에 올려놨습니다

2. pagination 클래스 common에 추가했습니다.
* page로 받아올 수 있게 수정할 예정