### PR TITLE
feat: 채권 시세정보 api/DB 연결

### DIFF
--- a/CrossFit ERD.sql
+++ b/CrossFit ERD.sql
@@ -46,7 +46,6 @@ CREATE TABLE SavingsProduct
     max_limit     VARCHAR(255),
     dcls_strt_day VARCHAR(8),
     dcls_end_day  VARCHAR(8),
-    RiskLevel     INT,
     hit           INT DEFAULT 0,
     FOREIGN KEY (ProductID) REFERENCES Product (ProductID)
 );
@@ -90,7 +89,6 @@ CREATE TABLE BondProduct
     crno              VARCHAR(13),   -- 법인등록번호
     scrsItmsKcd       VARCHAR(4),    -- 유가증권종목코드
     isinCd            VARCHAR(12),   -- ISIN코드
-    scrsItmsKcdNm     VARCHAR(50),   -- 유가증권종목코드명
     bondIsurNm        VARCHAR(100),  -- 채권발행인명
     isinCdNm          VARCHAR(100),  -- ISIN코드명
     bondIssuDt        VARCHAR(8),    -- 채권발행일자
@@ -106,11 +104,10 @@ CREATE TABLE BondProduct
     bondIntTcdNm      VARCHAR(50),   -- 채권이자형구분코드명
     intPayCyclCtt     VARCHAR(50),   -- 이자지급주기내용
     nxtmCopnDt        VARCHAR(8),    -- 차기표일자
-    rbVopnDt          VARCHAR(8),    -- 직전이표일자
     kbpScrsItmsKcdNm  VARCHAR(100),  -- 한국신용평가유가증권종목종류코드명
     niceScrsItmsKcdNm VARCHAR(100),  -- NICE평가정보유가증권종목종류코드명
     fnScrsItmsKcdNm   VARCHAR(100),  -- FN유가증권종목종류코드명
-    riskLevel         INT,           -- 위험도
+    clprPrc           DECIMAL(10, 2),-- 채권 종가
     hit               INT DEFAULT 0, -- 조회수, 기본값 0
     PRIMARY KEY (productID),         -- Primary Key 설정
     FOREIGN KEY (productID) REFERENCES Product (productID) ON DELETE CASCADE ON UPDATE CASCADE

--- a/src/main/java/com/be/finance/controller/BondProductController.java
+++ b/src/main/java/com/be/finance/controller/BondProductController.java
@@ -21,15 +21,26 @@ public class BondProductController {
 
     @Autowired
     private BondProductService bondProductService;
-    @Autowired
-    private FundProductService fundProductService;
 
     // 채권 데이터 DB 저장
     @GetMapping("/fetch-save")
     @ResponseBody
     public String fetchAndSaveBondProducts() {
         try {
+            bondProductService.fetchAndSaveBondProductPrices();
             bondProductService.fetchAndSaveBondProducts();
+            return "채권 데이터 저장 성공"; // 성공
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "채권 데이터 저장 중 오류 발생"; // 오류
+        }
+    }
+
+    @GetMapping("/fetch-test")
+    @ResponseBody
+    public String testFetch() {
+        try {
+            bondProductService.fetchAndSaveBondProductPrices();
             return "채권 데이터 저장 성공"; // 성공
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/be/finance/domain/BondProductVO.java
+++ b/src/main/java/com/be/finance/domain/BondProductVO.java
@@ -15,7 +15,6 @@ public class BondProductVO {
     private String crno; // 법인등록번호
     private String scrsItmsKcd; // 유가증권종목코드
     private String isinCd;               // ISIN코드
-    private String scrsItmsKcdNm;        // 유가증권종목코드명
     private String bondIsurNm; // 채권발행인명
     private String isinCdNm;             // ISIN코드명
     private String bondIssuDt; // 채권발행일자
@@ -31,10 +30,9 @@ public class BondProductVO {
     private String bondIntTcdNm;         // 채권이자형구분코드명
     private String intPayCyclCtt;        // 이자지급주기내용
     private String nxtmCopnDt;            // 차기표일자
-    private String rbVopnDt;             // 직전이표일자
     private String kbpScrsItmsKcdNm;    // 한국신용평가유가증권종목종류코드명
     private String niceScrsItmsKcdNm;    //NICE평가정보유가증권종목종류코드명
     private String fnScrsItmsKcdNm;     //FN유가증권종목종류코드명
-    private int riskLevel;            // 위험도
+    private double clprPrc;             // 채권전일종가
     private int hit;                     // 조회수
 }

--- a/src/main/java/com/be/finance/domain/SavingProductVO.java
+++ b/src/main/java/com/be/finance/domain/SavingProductVO.java
@@ -23,7 +23,6 @@ public class SavingProductVO {
     private Integer maxLimit;    // 최고한도
     private String dclsStrtDay; // 공시 시작일
     private String dclsEndDay;  // 공시 종료일
-    private int riskLevel;      // 리스크 레벨 (RiskLevel)
     private int hit;            // 조회수
 
     public int getProductId() {
@@ -144,14 +143,6 @@ public class SavingProductVO {
 
     public void setDclsEndDay(String dclsEndDay) {
         this.dclsEndDay = dclsEndDay;
-    }
-
-    public int getRiskLevel() {
-        return riskLevel;
-    }
-
-    public void setRiskLevel(int riskLevel) {
-        this.riskLevel = riskLevel;
     }
 
     public int getHit() {

--- a/src/main/java/com/be/finance/mapper/BondProductMapper.java
+++ b/src/main/java/com/be/finance/mapper/BondProductMapper.java
@@ -1,6 +1,7 @@
 package com.be.finance.mapper;
 
 import com.be.finance.domain.BondProductVO;
+import com.be.finance.domain.ProductVO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -9,6 +10,7 @@ import java.util.List;
 @Mapper
 public interface BondProductMapper {
     void insertBondProduct(BondProductVO bondProductVO);
+    void updateBondProductPrice(BondProductVO bondProductVO);
 
     // 전체 채권 리스트 조회
     List<BondProductVO> getBondProductsList();

--- a/src/main/java/com/be/finance/mapper/ProductMapper.java
+++ b/src/main/java/com/be/finance/mapper/ProductMapper.java
@@ -9,6 +9,5 @@ public interface ProductMapper {
 
     // 금융 상품(Product 테이블) 저장
     void insertProduct(ProductVO product);
-
     ProductVO findById(@Param("productId")int productId);
 }

--- a/src/main/java/com/be/stock/service/StockService.java
+++ b/src/main/java/com/be/stock/service/StockService.java
@@ -11,7 +11,6 @@ import org.json.JSONObject;
 import org.json.XML;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 

--- a/src/main/resources/mapper/BondProductMapper.xml
+++ b/src/main/resources/mapper/BondProductMapper.xml
@@ -6,24 +6,62 @@
 <mapper namespace="com.be.finance.mapper.BondProductMapper">
 
     <!-- 펀드 상품 삽입 -->
+<!--    <insert id="insertBondProduct" parameterType="com.be.finance.domain.BondProductVO">-->
+<!--        INSERT INTO BondProduct-->
+<!--        (-->
+<!--            productId, basDt, crno, scrsItmsKcd, isinCd, bondIsurNm, isinCdNm,-->
+<!--            bondIssuDt, bondIssuAmt, bondIssuCurCd, bondIssuCurCdNm, bondExprDt, bondPymtAmt,-->
+<!--            irtChngDcd, irtChngDcdNm, bondSrfcInrt, bondIntTcd, bondIntTcdNm, intPayCyclCtt,-->
+<!--            nxtmCopnDt, kbpScrsItmsKcdNm, niceScrsItmsKcdNm, fnScrsItmsKcdNm, clprPrc-->
+<!--            -->
+<!--        )-->
+<!--        VALUES-->
+<!--            (-->
+<!--                #{productId}, #{basDt}, #{crno}, #{scrsItmsKcd}, #{isinCd}, #{bondIsurNm}, #{isinCdNm},-->
+<!--                #{bondIssuDt}, #{bondIssuAmt}, #{bondIssuCurCd}, #{bondIssuCurCdNm}, #{bondExprDt}, #{bondPymtAmt},-->
+<!--                #{irtChngDcd}, #{irtChngDcdNm}, #{bondSrfcInrt}, #{bondIntTcd}, #{bondIntTcdNm}, #{intPayCyclCtt},-->
+<!--                #{nxtmCopnDt}, #{kbpScrsItmsKcdNm}, #{niceScrsItmsKcdNm}, #{fnScrsItmsKcdNm}, #{clprPrc}-->
+<!--                -->
+<!--            )-->
+<!--    </insert>-->
     <insert id="insertBondProduct" parameterType="com.be.finance.domain.BondProductVO">
         INSERT INTO BondProduct
         (
-            productId, basDt, crno, scrsItmsKcd, isinCd, scrsItmsKcdNm, bondIsurNm, isinCdNm,
-            bondIssuDt, bondIssuAmt, bondIssuCurCd, bondIssuCurCdNm, bondExprDt, bondPymtAmt,
-            irtChngDcd, irtChngDcdNm, bondSrfcInrt, bondIntTcd, bondIntTcdNm, intPayCyclCtt,
-            nxtmCopnDt, rbVopnDt, kbpScrsItmsKcdNm, niceScrsItmsKcdNm, fnScrsItmsKcdNm,
-            riskLevel, hit
+            productId, isinCd, clprPrc
         )
         VALUES
-            (
-                #{productId}, #{basDt}, #{crno}, #{scrsItmsKcd}, #{isinCd}, #{scrsItmsKcdNm}, #{bondIsurNm}, #{isinCdNm},
-                #{bondIssuDt}, #{bondIssuAmt}, #{bondIssuCurCd}, #{bondIssuCurCdNm}, #{bondExprDt}, #{bondPymtAmt},
-                #{irtChngDcd}, #{irtChngDcdNm}, #{bondSrfcInrt}, #{bondIntTcd}, #{bondIntTcdNm}, #{intPayCyclCtt},
-                #{nxtmCopnDt}, #{rbVopnDt}, #{kbpScrsItmsKcdNm}, #{niceScrsItmsKcdNm}, #{fnScrsItmsKcdNm},
-                0, 0
-            )
+        (
+            #{productId}, #{isinCd}, #{clprPrc}
+        )
     </insert>
+
+    <update id="updateBondProductPrice" parameterType="com.be.finance.domain.BondProductVO">
+        UPDATE BondProduct
+        SET
+            basDt = #{basDt},
+            crno = #{crno},
+            scrsItmsKcd = #{scrsItmsKcd},
+            bondIsurNm = #{bondIsurNm},
+            isinCdNm = #{isinCdNm},
+            bondIssuDt = #{bondIssuDt},
+            bondIssuAmt = #{bondIssuAmt},
+            bondIssuCurCd = #{bondIssuCurCd},
+            bondIssuCurCdNm = #{bondIssuCurCdNm},
+            bondExprDt = #{bondExprDt},
+            bondPymtAmt = #{bondPymtAmt},
+            irtChngDcd = #{irtChngDcd},
+            irtChngDcdNm = #{irtChngDcdNm},
+            bondSrfcInrt = #{bondSrfcInrt},
+            bondIntTcd = #{bondIntTcd},
+            bondIntTcdNm = #{bondIntTcdNm},
+            intPayCyclCtt = #{intPayCyclCtt},
+            nxtmCopnDt = #{nxtmCopnDt},
+            kbpScrsItmsKcdNm = #{kbpScrsItmsKcdNm},
+            niceScrsItmsKcdNm = #{niceScrsItmsKcdNm},
+            fnScrsItmsKcdNm = #{fnScrsItmsKcdNm}
+        WHERE
+            isinCd = #{isinCd};
+    </update>
 
     <!-- 채권 상품 조회 -->
     <select id="getBondProductsList" resultType="com.be.finance.domain.BondProductVO">

--- a/src/main/resources/mapper/SavingProductMapper.xml
+++ b/src/main/resources/mapper/SavingProductMapper.xml
@@ -10,12 +10,12 @@
         INSERT INTO SavingsProduct (
             ProductID, dcls_month, fin_co_no, kor_co_nm, fin_prdt_nm,
             join_way, mtrt_int, spcl_cnd, join_deny, join_member, etc_note,
-            max_limit, dcls_strt_day, dcls_end_day, RiskLevel, hit, fin_prdt_cd
+            max_limit, dcls_strt_day, dcls_end_day, hit, fin_prdt_cd
         ) VALUES (
                      #{productId}, #{dclsMonth}, #{finCoNo}, #{korCoNm}, #{finPrdtNm},
                      #{joinWay}, #{mtrtInt}, #{spclCnd}, #{joinDeny}, #{joinMember},
                      #{etcNote}, #{maxLimit}, #{dclsStrtDay}, #{dclsEndDay},
-                     1, 0, #{finPrdtCd}
+                      0, #{finPrdtCd}
                  );
     </insert>
 


### PR DESCRIPTION
1. 채권 fetch 시 채권 시세 정보를 먼저 insert하고, 해당 상품 코드와 일치하는 채권 기본 정보를 update하는 방식으로 수정했습니다.
* bond 테이블에 종가(clprPrc) column 추가, riskLevel, scrsItmsKcdNm, rbfCopnDt 삭제
* savings 테이블에 riskLevel column 삭제
* 관련 코드도 전부 지웠습니다.

product 관련 테이블 전부 드랍하고 노션에서 ddl 수정된 거 받아서 테이블 만들고 데이터 다시 받아주세요!!!