### PR TITLE
feat: 유튜브 콘텐츠 저장 및 조회 기능 추가

### DIFF
--- a/CrossFit ERD.sql
+++ b/CrossFit ERD.sql
@@ -172,6 +172,13 @@ CREATE TABLE PreferenceProductHits (
     foreign key (productID) references Product(productID) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+CREATE TABLE Youtube (
+    youtube_num INT PRIMARY KEY auto_increment,
+    youtube_url VARCHAR(255),
+    youtube_title VARCHAR(255),
+    youtube_context TEXT,
+    reg_date DATETIME DEFAULT CURRENT_TIMESTAMP
+);
 
 INSERT INTO `Portfolio` (`portfolioName`, `creationDate`, `total`, `expectedReturn`, `riskLevel`, `memberNum`)
 VALUES

--- a/src/main/java/com/be/config/RootConfig.java
+++ b/src/main/java/com/be/config/RootConfig.java
@@ -30,7 +30,8 @@ import javax.sql.DataSource;
         "com.be.cart.mapper",
         "com.be.member.mapper",
         "com.be.persona.mapper",
-        "com.be.hit.mapper"
+        "com.be.hit.mapper",
+        "com.be.youtube.mapper"
 })
 @ComponentScan(basePackages = {
         "com.be.portfolio.service",

--- a/src/main/java/com/be/youtube/controller/YoutubeController.java
+++ b/src/main/java/com/be/youtube/controller/YoutubeController.java
@@ -1,0 +1,50 @@
+package com.be.youtube.controller;
+
+import com.be.youtube.dto.req.YoutubeRequestDto;
+import com.be.youtube.service.YoutubeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/api/youtube")
+@RequiredArgsConstructor
+@Log4j
+public class YoutubeController {
+
+    private final YoutubeService youtubeService;
+
+    @PostMapping("/save")
+    public ResponseEntity<String> saveYoutube(@RequestBody YoutubeRequestDto youtubeRequestDto) {
+        try {
+            youtubeService.saveYoutubeData(youtubeRequestDto);
+            return ResponseEntity.ok("유튜브 데이터가 성공적으로 저장되었습니다.");
+        } catch (Exception e) {
+            log.error("유튜브 데이터 저장 중 오류 발생", e);
+            return ResponseEntity.status(500).body("유튜브 데이터 저장 중 오류가 발생했습니다.");
+        }
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<?> getAllYoutubeData() {
+        try {
+            return ResponseEntity.ok(youtubeService.getAllYoutubeDataWithoutContext());
+        } catch (Exception e) {
+            log.error("유튜브 데이터 조회 중 오류 발생", e);
+            return ResponseEntity.status(500).body("유튜브 데이터 조회 중 오류가 발생했습니다.");
+        }
+    }
+
+    @GetMapping("/{youtubeNum}")
+    public ResponseEntity<?> getYoutubeDetail(@PathVariable int youtubeNum) {
+        try {
+            return ResponseEntity.ok(youtubeService.getYoutubeDataById(youtubeNum));
+        } catch (Exception e) {
+            log.error("유튜브 상세 데이터 조회 중 오류 발생", e);
+            return ResponseEntity.status(500).body("유튜브 상세 데이터 조회 중 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/be/youtube/domain/YoutubeVO.java
+++ b/src/main/java/com/be/youtube/domain/YoutubeVO.java
@@ -1,0 +1,16 @@
+package com.be.youtube.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class YoutubeVO {
+    private int youtubeNum;
+    private String youtubeTitle;
+    private String youtubeUrl;
+    private String youtubeContext;
+    private String regDate;
+}

--- a/src/main/java/com/be/youtube/dto/req/YoutubeRequestDto.java
+++ b/src/main/java/com/be/youtube/dto/req/YoutubeRequestDto.java
@@ -1,0 +1,11 @@
+package com.be.youtube.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+public class YoutubeRequestDto {
+    private String youtubeTitle;
+    private String youtubeUrl;
+    private String youtubeContext;
+}

--- a/src/main/java/com/be/youtube/mapper/YoutubeMapper.java
+++ b/src/main/java/com/be/youtube/mapper/YoutubeMapper.java
@@ -1,0 +1,15 @@
+package com.be.youtube.mapper;
+
+import com.be.youtube.domain.YoutubeVO;
+import com.be.youtube.dto.req.YoutubeRequestDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface YoutubeMapper {
+    void insertYoutubeData(YoutubeRequestDto youtubeRequestDto);
+    List<YoutubeVO> selectAllYoutubeDataWithoutContext();
+    YoutubeRequestDto selectYoutubeDataById(@Param("youtubeNum") int youtubeNum);
+}

--- a/src/main/java/com/be/youtube/service/YoutubeService.java
+++ b/src/main/java/com/be/youtube/service/YoutubeService.java
@@ -1,0 +1,12 @@
+package com.be.youtube.service;
+
+import com.be.youtube.domain.YoutubeVO;
+import com.be.youtube.dto.req.YoutubeRequestDto;
+
+import java.util.List;
+
+public interface YoutubeService {
+    void saveYoutubeData(YoutubeRequestDto youtubeRequestDto);
+    List<YoutubeVO> getAllYoutubeDataWithoutContext();
+    YoutubeRequestDto getYoutubeDataById(int youtubeNum);
+}

--- a/src/main/java/com/be/youtube/service/YoutubeServiceImpl.java
+++ b/src/main/java/com/be/youtube/service/YoutubeServiceImpl.java
@@ -1,0 +1,38 @@
+package com.be.youtube.service;
+
+import com.be.youtube.domain.YoutubeVO;
+import com.be.youtube.dto.req.YoutubeRequestDto;
+import com.be.youtube.mapper.YoutubeMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Log4j
+public class YoutubeServiceImpl implements YoutubeService {
+    private final YoutubeMapper youtubeMapper;
+
+    @Override
+    public void saveYoutubeData(YoutubeRequestDto youtubeRequestDto) {
+        try {
+            youtubeMapper.insertYoutubeData(youtubeRequestDto);
+            log.info("유튜브 데이터가 성공적으로 저장되었습니다: " + youtubeRequestDto);
+        } catch (Exception e) {
+            log.error("유튜브 데이터 저장 중 오류 발생", e);
+            throw e;
+        }
+    }
+
+    @Override
+    public List<YoutubeVO> getAllYoutubeDataWithoutContext() {
+        return youtubeMapper.selectAllYoutubeDataWithoutContext();
+    }
+
+    @Override
+    public YoutubeRequestDto getYoutubeDataById(int youtubeNum) {
+        return youtubeMapper.selectYoutubeDataById(youtubeNum);
+    }
+}

--- a/src/main/resources/mapper/YoutubeMapper.xml
+++ b/src/main/resources/mapper/YoutubeMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.be.youtube.mapper.YoutubeMapper">
+
+    <insert id="insertYoutubeData">
+        INSERT INTO youtube (youtube_title, youtube_url, youtube_context, reg_date)
+        VALUES (#{youtubeTitle}, #{youtubeUrl}, #{youtubeContext}, NOW())
+    </insert>
+
+    <select id="selectAllYoutubeDataWithoutContext" resultType="com.be.youtube.domain.YoutubeVO">
+        SELECT youtube_num, youtube_title, youtube_url, reg_date
+        FROM youtube
+        ORDER BY reg_date DESC
+    </select>
+
+    <select id="selectYoutubeDataById" parameterType="int" resultType="com.be.youtube.dto.req.YoutubeRequestDto">
+        SELECT youtube_num, youtube_title, youtube_url, youtube_context
+        FROM youtube
+        WHERE youtube_num = #{youtubeNum}
+    </select>
+</mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -28,6 +28,7 @@
         <mapper resource="mapper/MemberRoleMapper.xml"/>
         <mapper resource="mapper/AgeGroupProductHitsMapper.xml"/>
         <mapper resource="mapper/PreferenceProductHitsMapper.xml"/>
+        <mapper resource="mapper/YoutubeMapper.xml"/>
 
     </mappers>
 


### PR DESCRIPTION
1. 관리자가 사용하는 유튜브 요약 저장 기능 추가 (유튜브 제목, 유튜브 URL, 유튜브 본문 입력 후 저장)
2. 사용자가 금융 유튜브 페이지 방문 시 유튜브 본문 내용 제외하고 제목, 및 URL만 전송
3. 사용자가 유튜브 요약 상세보기 클릭 시 본문 내용 받아와서 출력하도록 기능 설정 