### PR TITLE
feat: 포트폴리오 계산 기능 추가 및 flask 서버 연동

### DIFF
--- a/CrossFit ERD.sql
+++ b/CrossFit ERD.sql
@@ -141,7 +141,7 @@ CREATE TABLE `Portfolio`
     `creationDate`   DATETIME        NULL,
     `total`          DECIMAL(15, 2)  NULL,
     `expectedReturn` DECIMAL(5, 2)   NULL,
-    `riskLevel`      INT             NULL,
+    `riskLevel`      DECIMAL(5, 2)   NULL,
     `memberNum`      BIGINT UNSIGNED NOT NULL
 );
 
@@ -153,6 +153,7 @@ CREATE TABLE `PortfolioItem`
     `stockCode`       VARCHAR(10)   NULL,
     `amount`          INT           NULL,
     `expectedReturn`  DECIMAL(5, 2) NULL,
+    `riskLevel`       INT           NULL,
     FOREIGN KEY (`portfolioID`) REFERENCES `portfolio` (`portfolioID`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
@@ -182,34 +183,34 @@ CREATE TABLE Youtube (
 
 INSERT INTO `Portfolio` (`portfolioName`, `creationDate`, `total`, `expectedReturn`, `riskLevel`, `memberNum`)
 VALUES
-    ('Portfolio 1', NOW(), 2500000, 5.50, 3, 1),
-    ('Portfolio 2', NOW(), 4500000, 6.20, 2, 2),
-    ('Portfolio 3', NOW(), 6700000, 4.75, 4, 1),
-    ('Portfolio 4', NOW(), 8900000, 5.10, 5, 2),
-    ('Portfolio 5', NOW(), 3200000, 7.00, 1, 1);
+    ('Portfolio 1', NOW(), 2500000, 5.50, 3.10, 1),
+    ('Portfolio 2', NOW(), 4500000, 6.20, 2.20, 2),
+    ('Portfolio 3', NOW(), 6700000, 4.75, 4.30, 1),
+    ('Portfolio 4', NOW(), 8900000, 5.10, 5.42, 2),
+    ('Portfolio 5', NOW(), 3200000, 7.00, 1.11, 1);
 
-INSERT INTO `PortfolioItem` (`portfolioID`, `productID`, `stockCode`, `amount`, `expectedReturn`)
+INSERT INTO `PortfolioItem` (`portfolioID`, `productID`, `stockCode`, `amount`, `expectedReturn`, `riskLevel`)
 VALUES
-(1, NULL, '000020', 7, 5.10),
-(1, 1001, NULL, 100000, 6.00),
-(1, NULL, '000040', 3, 4.80),
-(1, 1002, NULL, 150000, 5.50),
-(2, 1003, NULL, 120000, 6.30),
-(2, NULL, '000050', 9, 7.20),
-(2, 1004, NULL, 180000, 6.10),
-(2, NULL, '000070', 5, 5.40),
-(3, NULL, '000075', 4, 5.00),
-(3, 1005, NULL, 130000, 7.00),
-(3, NULL, '000080', 8, 6.80),
-(3, 1006, NULL, 110000, 5.90),
-(4, 1007, NULL, 140000, 5.50),
-(4, NULL, '000087', 6, 6.10),
-(4, 1008, NULL, 160000, 7.50),
-(4, NULL, '000100', 2, 4.90),
-(5, NULL, '000105', 5, 5.60),
-(5, 1009, NULL, 170000, 6.70),
-(5, NULL, '000120', 8, 4.70),
-(5, 1010, NULL, 190000, 7.20);
+(1, NULL, '000020', 7, 5.10, 1),
+(1, 1001, NULL, 100000, 6.00, 2),
+(1, NULL, '000040', 3, 4.80, 3),
+(1, 1002, NULL, 150000, 5.50, 3),
+(2, 1003, NULL, 120000, 6.30, 4),
+(2, NULL, '000050', 9, 7.20, 3),
+(2, 1004, NULL, 180000, 6.10, 4),
+(2, NULL, '000070', 5, 5.40, 3),
+(3, NULL, '000075', 4, 5.00, 3),
+(3, 1005, NULL, 130000, 7.00,1),
+(3, NULL, '000080', 8, 6.80, 2),
+(3, 1006, NULL, 110000, 5.90, 3),
+(4, 1007, NULL, 140000, 5.50, 3),
+(4, NULL, '000087', 6, 6.10, 1),
+(4, 1008, NULL, 160000, 7.50, 5),
+(4, NULL, '000100', 2, 4.90, 6),
+(5, NULL, '000105', 5, 5.60, 1),
+(5, 1009, NULL, 170000, 6.70, 2),
+(5, NULL, '000120', 8, 4.70, 5),
+(5, 1010, NULL, 190000, 7.20, 2);
 
 CREATE TABLE `CartItem`
 (

--- a/src/main/java/com/be/portfolio/controller/PortfolioController.java
+++ b/src/main/java/com/be/portfolio/controller/PortfolioController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/portfolio")
@@ -32,8 +33,8 @@ public class PortfolioController {
     }
 
     @PostMapping
-    public ResponseEntity<PortfolioResDto> createPortfolio(@RequestBody @Valid PortfolioReqDto portfolioReqDto, HttpServletRequest request) {
-        return ResponseEntity.ok(portfolioService.createPortfolio(portfolioReqDto, jwtUtils.extractMemberNum(request)));
+    public ResponseEntity<PortfolioResDto> createPortfolio(@RequestBody @Valid List<Object> portfolioItems, @RequestParam String name, HttpServletRequest request) {
+        return ResponseEntity.ok(portfolioService.createPortfolio(portfolioItems, name, jwtUtils.extractMemberNum(request)));
     }
 
     @DeleteMapping("/{portfolioId}")

--- a/src/main/java/com/be/portfolio/domain/PortfolioItemVO.java
+++ b/src/main/java/com/be/portfolio/domain/PortfolioItemVO.java
@@ -9,10 +9,9 @@ import lombok.*;
 public class PortfolioItemVO {
     private int portfolioItemId;
     public int portfolioId;
-    private int productId;
+    private Integer productId;
     private String stockCode;
     private int amount;
     private double expectedReturn;
-    private String productType;
-    private int dailyPrice;
+    private int riskLevel;
 }

--- a/src/main/java/com/be/portfolio/domain/PortfolioVO.java
+++ b/src/main/java/com/be/portfolio/domain/PortfolioVO.java
@@ -14,9 +14,9 @@ public class PortfolioVO {
     private int portfolioId;
     private String portfolioName;
     private Date creationDate;
-    private int total;
-    private int expectedReturn;
-    private int riskLevel;
+    private double total;
+    private double expectedReturn;
+    private double riskLevel;
     private long memberNum;
 
     private List<PortfolioItemVO> portfolioItems = new ArrayList<>();

--- a/src/main/java/com/be/portfolio/dto/req/BondItemReqDto.java
+++ b/src/main/java/com/be/portfolio/dto/req/BondItemReqDto.java
@@ -1,0 +1,8 @@
+package com.be.portfolio.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class BondItemReqDto {
+}

--- a/src/main/java/com/be/portfolio/dto/req/FundItemReqDto.java
+++ b/src/main/java/com/be/portfolio/dto/req/FundItemReqDto.java
@@ -1,0 +1,4 @@
+package com.be.portfolio.dto.req;
+
+public class FundItemReqDto {
+}

--- a/src/main/java/com/be/portfolio/dto/req/PortfolioItemReqDto.java
+++ b/src/main/java/com/be/portfolio/dto/req/PortfolioItemReqDto.java
@@ -13,10 +13,11 @@ import lombok.NoArgsConstructor;
 @Builder
 public class PortfolioItemReqDto {
     private int portfolioId;
-    private int productId;
+    private Integer productId;
     private String stockCode;
     private int amount;
     private double expectedReturn;
+    private int riskLevel;
 
     public static PortfolioItemReqDto of(PortfolioItemResDto resDto) {
         return resDto == null ? null : PortfolioItemReqDto.builder()
@@ -25,6 +26,7 @@ public class PortfolioItemReqDto {
                 .stockCode(resDto.getStockCode())
                 .amount(resDto.getAmount())
                 .expectedReturn(resDto.getExpectedReturn())
+                .riskLevel(resDto.getRiskLevel())
                 .build();
     }
 
@@ -35,6 +37,7 @@ public class PortfolioItemReqDto {
                 .stockCode(stockCode)
                 .amount(amount)
                 .expectedReturn(expectedReturn)
+                .riskLevel(riskLevel)
                 .build();
     }
 }

--- a/src/main/java/com/be/portfolio/dto/req/PortfolioReqDto.java
+++ b/src/main/java/com/be/portfolio/dto/req/PortfolioReqDto.java
@@ -17,9 +17,9 @@ import java.util.List;
 @Builder
 public class PortfolioReqDto {
     private String portfolioName;
-    private int total;
-    private int expectedReturn;
-    private int riskLevel;
+    private double total;
+    private double expectedReturn;
+    private double riskLevel;
     private long memberNum;
 
     private List<PortfolioItemReqDto> portfolioItems;

--- a/src/main/java/com/be/portfolio/dto/req/SavingItemReqDto.java
+++ b/src/main/java/com/be/portfolio/dto/req/SavingItemReqDto.java
@@ -1,0 +1,4 @@
+package com.be.portfolio.dto.req;
+
+public class SavingItemReqDto {
+}

--- a/src/main/java/com/be/portfolio/dto/req/StockItemReqDto.java
+++ b/src/main/java/com/be/portfolio/dto/req/StockItemReqDto.java
@@ -1,0 +1,4 @@
+package com.be.portfolio.dto.req;
+
+public class StockItemReqDto {
+}

--- a/src/main/java/com/be/portfolio/dto/res/PortfolioItemResDto.java
+++ b/src/main/java/com/be/portfolio/dto/res/PortfolioItemResDto.java
@@ -9,12 +9,11 @@ import lombok.Data;
 public class PortfolioItemResDto {
     private int portfolioItemId;
     private int portfolioId;
-    private int productId;
+    private Integer productId;
     private String stockCode;
     private int amount;
     private double expectedReturn;
-    private String productType;
-    private int dailyPrice;
+    private int riskLevel;
 
     public static PortfolioItemResDto of(PortfolioItemVO vo) {
         return vo == null ? null : PortfolioItemResDto.builder()
@@ -24,11 +23,9 @@ public class PortfolioItemResDto {
                 .stockCode(vo.getStockCode())
                 .amount(vo.getAmount())
                 .expectedReturn(vo.getExpectedReturn())
-                .productType(vo.getProductType())
-                .dailyPrice(vo.getDailyPrice())
+                .riskLevel(vo.getRiskLevel())
                 .build();
     }
-
 
     public PortfolioItemVO toVo() {
         return PortfolioItemVO.builder()
@@ -38,8 +35,7 @@ public class PortfolioItemResDto {
                 .stockCode(stockCode)
                 .amount(amount)
                 .expectedReturn(expectedReturn)
-                .productType(productType)
-                .dailyPrice(dailyPrice)
+                .riskLevel(riskLevel)
                 .build();
     }
 }

--- a/src/main/java/com/be/portfolio/dto/res/PortfolioResDto.java
+++ b/src/main/java/com/be/portfolio/dto/res/PortfolioResDto.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -18,13 +17,13 @@ public class PortfolioResDto {
     private int portfolioId;
     private String portfolioName;
     private Date creationDate;
-    private int total;
-    private int expectedReturn;
-    private int riskLevel;
+    private double total;
+    private double expectedReturn;
+    private double riskLevel;
     private long memberNum;
 
     private List<PortfolioItemResDto> portfolioItems;
-    private PortfolioPortionDto portion;
+//    private PortfolioPortionDto portion;
 
     public static PortfolioResDto of(PortfolioVO vo) {
         return vo == null ? null : PortfolioResDto.builder()

--- a/src/main/java/com/be/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/be/portfolio/service/PortfolioService.java
@@ -13,13 +13,13 @@ public interface PortfolioService {
     PortfolioResDto getPortfolio(int portfolioId);
     List<PortfolioResDto> getPortfolioList(long memberNum);
     List<PortfolioItemResDto> getPortfolioItems(int portfolioId);
-    PortfolioResDto createPortfolio(PortfolioReqDto portfolioReqDto, long memberNum);
+    PortfolioResDto createPortfolio(List<Object> portfolioItems, String portfolioName, long memberNum);
     PortfolioResDto updatePortfolio(PortfolioVO portfolioVO);
 
     @Scheduled(cron = "0 0 0 * * ?")
     void updateAllPortfolio();
 
     void deletePortfolio(int id);
-    PortfolioReqDto calculatePortfolio(PortfolioReqDto portfolioReqDto);
-    PortfolioPortionDto calculatePortion(List<PortfolioItemResDto> portfolioItems);
+    PortfolioReqDto calculatePortfolio(PortfolioReqDto portfolioReqDto, List<Object> portfolioItems);
+//    PortfolioPortionDto calculatePortion(List<PortfolioItemResDto> portfolioItems);
 }

--- a/src/main/java/com/be/portfolio/service/PortfolioServiceImpl.java
+++ b/src/main/java/com/be/portfolio/service/PortfolioServiceImpl.java
@@ -9,13 +9,13 @@ import com.be.portfolio.dto.res.PortfolioResDto;
 import com.be.portfolio.mapper.PortfolioMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -32,10 +32,10 @@ public class PortfolioServiceImpl implements PortfolioService {
     @Override
     public PortfolioResDto getPortfolio(int portfolioId) {
         PortfolioResDto portfolio = PortfolioResDto.of(portfolioMapper.getPortfolio(portfolioId));
-        portfolio.setPortfolioItems(portfolioMapper.getPortfolioItemList(portfolio.getPortfolioId()).stream().map(PortfolioItemResDto::of).toList());
-        portfolio.setPortion(calculatePortion(getPortfolioItems(portfolio.getPortfolioId())));
-        
-        return Optional.ofNullable(portfolio)
+        portfolio.setPortfolioItems(getPortfolioItems(portfolioId));
+//        portfolio.setPortion(calculatePortion(getPortfolioItems(portfolio.getPortfolioId())));
+
+        return Optional.of(portfolio)
                 .orElseThrow(NoSuchElementException::new);
     }
 
@@ -46,10 +46,13 @@ public class PortfolioServiceImpl implements PortfolioService {
     }
 
     @Override
-    public PortfolioResDto createPortfolio(PortfolioReqDto portfolio, long memberNum) {
+    public PortfolioResDto createPortfolio(List<Object> portfolioItems, String portfolioName, long memberNum) {
         // 포트폴리오 계산 기능(개발중)
-//        portfolio = calculatePortfolio(portfolio);
+        PortfolioReqDto portfolio = new PortfolioReqDto();
         portfolio.setMemberNum(memberNum);
+        portfolio.setPortfolioName(portfolioName);
+        portfolio = calculatePortfolio(portfolio, portfolioItems);
+
         int portfolioId = portfolioMapper.insertPortfolio(portfolio.toVo());
 
         for(PortfolioItemReqDto portfolioItem : portfolio.getPortfolioItems()) {
@@ -60,7 +63,7 @@ public class PortfolioServiceImpl implements PortfolioService {
         }
 
         PortfolioResDto resDto = getPortfolio(portfolioId);
-        resDto.setPortion(calculatePortion(getPortfolioItems(resDto.getPortfolioId())));
+//        resDto.setPortion(calculatePortion(getPortfolioItems(resDto.getPortfolioId())));
 
         return resDto;
     }
@@ -93,46 +96,70 @@ public class PortfolioServiceImpl implements PortfolioService {
     }
 
     @Override
-    public PortfolioReqDto calculatePortfolio(PortfolioReqDto dto) {
+    public PortfolioReqDto calculatePortfolio(PortfolioReqDto portfolio, List<Object> portfolioItems) {
+        // 파이썬 플라스크 서버 연결 + 계산 + 데이터 반환
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://localhost:5000/api/portfolio/calculate";
+        HttpEntity<List<Object>> requestEntity = new HttpEntity<>(portfolioItems);
+
         try {
-//            ProcessBuilder processBuilder = new ProcessBuilder("python", "src/main/java/com/be/portfolio/service/test.py");
-//            Process process = processBuilder.start();
-//
-//            InputStream inputStream = process.getInputStream();
-//            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-//
-//            String line;
-//            while((line = reader.readLine()) != null) {
-//                System.out.println(line);
-//            }
+            ResponseEntity<Map> responseEntity = restTemplate.exchange(url, HttpMethod.POST, requestEntity, Map.class);
 
-            // 파이썬 플라스크 서버 연결 + 계산 + 반환
-            // portfolio의 expectedReturn, riskLevel, portfolioItem의 expectedReturn 반환
-            dto.setTotal(100);
-            dto.setExpectedReturn(10000);
-            dto.setRiskLevel(14);
-            //
+            if (responseEntity.getStatusCode().is2xxSuccessful()) {
+                System.out.println("Response: " + responseEntity.getBody());
+            } else {
+                // 예외 처리해야됨
+                System.out.println("Request failed: " + responseEntity.getStatusCode());
+            }
 
+            // portfolio의 expectedReturn, riskLevel, total, portfolioItem의 expectedReturn, riskLevel, amount을  Map에 반환
+            Map<String, Object> data = responseEntity.getBody();
 
+            double portfolioExpectedReturn = (Double) data.get("expectedReturn");
+            double portfolioRiskLevel = (Double) data.get("riskLevel");
+            double total = (Double) data.get("total");
+
+            portfolio.setTotal(total);
+            portfolio.setExpectedReturn(portfolioExpectedReturn);
+            portfolio.setRiskLevel(portfolioRiskLevel);
+
+            List<Map<String, Object>> tempList = (List<Map<String, Object>>) data.get("portfolioItems");
+            List<PortfolioItemReqDto> portfolioItemList = new ArrayList<>();
+            for(Map item : tempList) {
+                PortfolioItemReqDto portfolioItem = new PortfolioItemReqDto();
+                portfolioItem.setAmount((Integer) item.get("amount"));
+                portfolioItem.setExpectedReturn((Double) item.get("expectedReturn"));
+                portfolioItem.setRiskLevel((Integer) item.get("riskLevel"));
+                if(item.get("productId") == null) {
+                    portfolioItem.setStockCode((String) item.get("stockCode"));
+                } else {
+                    portfolioItem.setProductId((int) item.get("productId"));
+                }
+                portfolioItemList.add(portfolioItem);
+            }
+
+            portfolio.setPortfolioItems(portfolioItemList);
+
+            log.info(portfolio);
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return dto;
+        return portfolio;
     }
 
-    @Override
-    public PortfolioPortionDto calculatePortion(List<PortfolioItemResDto> portfolioItems) {
-        PortfolioPortionDto dto = new PortfolioPortionDto();
-
-        for(PortfolioItemResDto item : portfolioItems) {
-            switch(item.getProductType() == null ? "stock" : item.getProductType()) {
-                case "S" -> dto.setTotalSaving(dto.getTotalSaving() + item.getAmount());
-                case "F" -> dto.setTotalFund(dto.getTotalFund() + item.getAmount());
-                case "B" -> dto.setTotalBond(dto.getTotalBond() + item.getAmount());
-                case "stock" -> dto.setTotalStock(dto.getTotalStock() + (item.getAmount() * item.getDailyPrice()));
-            }
-        }
-
-        return dto;
-    }
+//    @Override
+//    public PortfolioPortionDto calculatePortion(List<PortfolioItemResDto> portfolioItems) {
+//        PortfolioPortionDto dto = new PortfolioPortionDto();
+//
+//        for(PortfolioItemResDto item : portfolioItems) {
+//            switch(item.getProductType() == null ? "stock" : item.getProductType()) {
+//                case "S" -> dto.setTotalSaving(dto.getTotalSaving() + item.getAmount());
+//                case "F" -> dto.setTotalFund(dto.getTotalFund() + item.getAmount());
+//                case "B" -> dto.setTotalBond(dto.getTotalBond() + item.getAmount());
+//                case "stock" -> dto.setTotalStock(dto.getTotalStock() + (item.getAmount() * item.getDailyPrice()));
+//            }
+//        }
+//
+//        return dto;
+//    }
 }

--- a/src/main/resources/mapper/PortfolioMapper.xml
+++ b/src/main/resources/mapper/PortfolioMapper.xml
@@ -38,24 +38,19 @@
         where memberNum = #{memberNum}
     </select>
     <select id="getPortfolioItemList" resultType="com.be.portfolio.domain.PortfolioItemVO">
-        select pi.portfolioitemID, pi.portfolioID, pi.productID, pi.stockCode, pi.amount, pi.expectedReturn, p.productType, s.dailyPrice
-        from portfolioitem pi
-                 left outer join product p
-                                 on pi.productID = p.productID
-                 left outer join stock s
-                                 on pi.stockCode = s.stockCode
-        where pi.portfolioID = #{portfolioId}
+        select * from portfolioitem
+        where portfolioID = #{portfolioId}
     </select>
     <insert id="insertPortfolio">
-        insert into portfolio(creationDate, total, expectedReturn, riskLevel, portfolioName, memberNum)
-        values(CURRENT_TIMESTAMP, #{total}, #{expectedReturn}, #{riskLevel}, #{portfolioName}, #{memberNum})
+        insert into portfolio(portfolioName, creationDate, total, expectedReturn, riskLevel, memberNum)
+        values(#{portfolioName}, CURRENT_TIMESTAMP, #{total}, #{expectedReturn}, #{riskLevel}, #{memberNum})
         <selectKey resultType="Int" keyProperty="portfolioId" keyColumn="portfolioID" order="AFTER">
             SELECT LAST_INSERT_ID()
         </selectKey>
     </insert>
     <insert id="insertPortfolioItem">
-        insert into portfolioitem(portfolioID, productID, stockCode, amount, expectedReturn)
-        values(#{portfolioId}, #{productId}, #{stockCode}, #{amount}, #{expectedReturn})
+        insert into portfolioitem(portfolioID, productID, stockCode, amount, expectedReturn, riskLevel)
+        values(#{portfolioId}, #{productId}, #{stockCode}, #{amount}, #{expectedReturn}, #{riskLevel})
     </insert>
     <update id="updatePortfolio">
         update portfolio set total=#{total}, expectedReturn=#{expectedReturn}, riskLevel=#{riskLevel} where portfolioID=#{portfolioId}


### PR DESCRIPTION
1. 포트폴리오 생성 시 flask 서버에서 계산해서 데이터 반환하도록 연동해놨습니다.
* flask BE 받으셔서 서버 실행하고 요청 보내셔야 됩니다

2. 포트폴리오 패키지 내 변수 타입 & 포트폴리오 관련 DB 테이블 column 수정 있습니다.
* portfolio와 portfolioitem 테이블 드랍하고 해당 테이블 ERD.sql에서 다시 만들어주세요!