### PR TITLE
feat: calculatePortion 기능 추가(포트폴리오 상품별 비율 계산 기능)

### DIFF
--- a/CrossFit ERD.sql
+++ b/CrossFit ERD.sql
@@ -176,6 +176,7 @@ CREATE TABLE `PortfolioItem`
     FOREIGN KEY (`portfolioID`) REFERENCES `portfolio` (`portfolioID`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+
 INSERT INTO `Portfolio` (`portfolioName`, `creationDate`, `total`, `expectedReturn`, `riskLevel`, `memberNum`)
 VALUES ('Portfolio 1', NOW(), 2500000, 5.50, 3, 1),
        ('Portfolio 2', NOW(), 4500000, 6.20, 2, 2),

--- a/CrossFit ERD.sql
+++ b/CrossFit ERD.sql
@@ -165,44 +165,45 @@ CREATE TABLE `Portfolio`
 
 CREATE TABLE `PortfolioItem`
 (
-    `portfolioItemID` INT           NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    `portfolioID`     INT           NOT NULL,
-    `productID`       INT           NULL,
-    `stockCode`       VARCHAR(10)   NULL,
-    `amount`          INT           NULL,
-    `expectedReturn`  DECIMAL(5, 2) NULL,
-    `riskLevel`       INT           NULL,
+    `portfolioItemID` INT               NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `portfolioID`     INT               NOT NULL,
+    `productID`       INT               NULL,
+    `stockCode`       VARCHAR(10)       NULL,
+    `amount`          DECIMAL(15, 2)    NULL,
+    `expectedReturn`  DECIMAL(5, 2)     NULL,
+    `riskLevel`       INT               NULL,
+    `productType`     CHAR(1)           NULL,
     FOREIGN KEY (`portfolioID`) REFERENCES `portfolio` (`portfolioID`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 INSERT INTO `Portfolio` (`portfolioName`, `creationDate`, `total`, `expectedReturn`, `riskLevel`, `memberNum`)
-VALUES ('Portfolio 1', NOW(), 2500000, 5.50, 3.10, 1),
-       ('Portfolio 2', NOW(), 4500000, 6.20, 2.20, 2),
-       ('Portfolio 3', NOW(), 6700000, 4.75, 4.30, 1),
-       ('Portfolio 4', NOW(), 8900000, 5.10, 5.42, 2),
-       ('Portfolio 5', NOW(), 3200000, 7.00, 1.11, 1);
+VALUES ('Portfolio 1', NOW(), 2500000, 5.50, 3, 1),
+       ('Portfolio 2', NOW(), 4500000, 6.20, 2, 2),
+       ('Portfolio 3', NOW(), 6700000, 4.75, 4, 1),
+       ('Portfolio 4', NOW(), 8900000, 5.10, 5, 2),
+       ('Portfolio 5', NOW(), 3200000, 7.00, 1, 1);
 
-INSERT INTO `PortfolioItem` (`portfolioID`, `productID`, `stockCode`, `amount`, `expectedReturn`, `riskLevel`)
-VALUES (1, NULL, '000020', 7, 5.10, 1),
-       (1, 1001, NULL, 100000, 6.00, 2),
-       (1, NULL, '000040', 3, 4.80, 3),
-       (1, 1002, NULL, 150000, 5.50, 3),
-       (2, 1003, NULL, 120000, 6.30, 4),
-       (2, NULL, '000050', 9, 7.20, 3),
-       (2, 1004, NULL, 180000, 6.10, 4),
-       (2, NULL, '000070', 5, 5.40, 3),
-       (3, NULL, '000075', 4, 5.00, 3),
-       (3, 1005, NULL, 130000, 7.00, 1),
-       (3, NULL, '000080', 8, 6.80, 2),
-       (3, 1006, NULL, 110000, 5.90, 3),
-       (4, 1007, NULL, 140000, 5.50, 3),
-       (4, NULL, '000087', 6, 6.10, 1),
-       (4, 1008, NULL, 160000, 7.50, 5),
-       (4, NULL, '000100', 2, 4.90, 6),
-       (5, NULL, '000105', 5, 5.60, 1),
-       (5, 1009, NULL, 170000, 6.70, 2),
-       (5, NULL, '000120', 8, 4.70, 5),
-       (5, 1010, NULL, 190000, 7.20, 2);
+INSERT INTO `PortfolioItem` (`portfolioID`, `productID`, `stockCode`, `amount`, `expectedReturn`, `riskLevel`, `productType`)
+VALUES (1, NULL, '000020', 7, 5.10, 1, NULL),
+       (1, 1001, NULL, 100000, 6.00, 2, 'S'),
+       (1, NULL, '000040', 3, 4.80, 3, NULL),
+       (1, 1002, NULL, 150000, 5.50, 3, 'F'),
+       (2, 1003, NULL, 120000, 6.30, 4, 'B'),
+       (2, NULL, '000050', 9, 7.20, 3, NULL),
+       (2, 1004, NULL, 180000, 6.10, 4, 'F'),
+       (2, NULL, '000070', 5, 5.40, 3, NULL),
+       (3, NULL, '000075', 4, 5.00, 3, NULL),
+       (3, 1005, NULL, 130000, 7.00, 1, 'F'),
+       (3, NULL, '000080', 8, 6.80, 2, NULL),
+       (3, 1006, NULL, 110000, 5.90, 3, 'F'),
+       (4, 1007, NULL, 140000, 5.50, 3, 'F'),
+       (4, NULL, '000087', 6, 6.10, 1, NULL),
+       (4, 1008, NULL, 160000, 7.50, 5, 'S'),
+       (4, NULL, '000100', 2, 4.90, 6, NULL),
+       (5, NULL, '000105', 5, 5.60, 1, NULL),
+       (5, 1009, NULL, 170000, 6.70, 2, 'F'),
+       (5, NULL, '000120', 8, 4.70, 5, NULL),
+       (5, 1010, NULL, 190000, 7.20, 2, 'B');
 
 CREATE TABLE `CartItem`
 (

--- a/src/main/java/com/be/portfolio/domain/PortfolioItemVO.java
+++ b/src/main/java/com/be/portfolio/domain/PortfolioItemVO.java
@@ -11,7 +11,8 @@ public class PortfolioItemVO {
     public int portfolioId;
     private Integer productId;
     private String stockCode;
-    private int amount;
+    private double amount;
     private double expectedReturn;
     private int riskLevel;
+    private char productType;
 }

--- a/src/main/java/com/be/portfolio/dto/req/PortfolioItemReqDto.java
+++ b/src/main/java/com/be/portfolio/dto/req/PortfolioItemReqDto.java
@@ -15,9 +15,10 @@ public class PortfolioItemReqDto {
     private int portfolioId;
     private Integer productId;
     private String stockCode;
-    private int amount;
+    private double amount;
     private double expectedReturn;
     private int riskLevel;
+    private char productType;
 
     public static PortfolioItemReqDto of(PortfolioItemResDto resDto) {
         return resDto == null ? null : PortfolioItemReqDto.builder()
@@ -27,6 +28,7 @@ public class PortfolioItemReqDto {
                 .amount(resDto.getAmount())
                 .expectedReturn(resDto.getExpectedReturn())
                 .riskLevel(resDto.getRiskLevel())
+                .productType(resDto.getProductType())
                 .build();
     }
 
@@ -38,6 +40,7 @@ public class PortfolioItemReqDto {
                 .amount(amount)
                 .expectedReturn(expectedReturn)
                 .riskLevel(riskLevel)
+                .productType(productType)
                 .build();
     }
 }

--- a/src/main/java/com/be/portfolio/dto/res/PortfolioItemResDto.java
+++ b/src/main/java/com/be/portfolio/dto/res/PortfolioItemResDto.java
@@ -11,9 +11,10 @@ public class PortfolioItemResDto {
     private int portfolioId;
     private Integer productId;
     private String stockCode;
-    private int amount;
+    private double amount;
     private double expectedReturn;
     private int riskLevel;
+    private char productType;
 
     public static PortfolioItemResDto of(PortfolioItemVO vo) {
         return vo == null ? null : PortfolioItemResDto.builder()
@@ -24,6 +25,7 @@ public class PortfolioItemResDto {
                 .amount(vo.getAmount())
                 .expectedReturn(vo.getExpectedReturn())
                 .riskLevel(vo.getRiskLevel())
+                .productType(vo.getProductType())
                 .build();
     }
 
@@ -36,6 +38,7 @@ public class PortfolioItemResDto {
                 .amount(amount)
                 .expectedReturn(expectedReturn)
                 .riskLevel(riskLevel)
+                .productType(productType)
                 .build();
     }
 }

--- a/src/main/java/com/be/portfolio/dto/res/PortfolioPortionDto.java
+++ b/src/main/java/com/be/portfolio/dto/res/PortfolioPortionDto.java
@@ -8,8 +8,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PortfolioPortionDto {
-    private int totalSaving;
-    private int totalBond;
-    private int totalFund;
-    private int totalStock;
+    private double totalSaving;
+    private double totalBond;
+    private double totalFund;
+    private double totalStock;
 }

--- a/src/main/java/com/be/portfolio/dto/res/PortfolioResDto.java
+++ b/src/main/java/com/be/portfolio/dto/res/PortfolioResDto.java
@@ -23,7 +23,7 @@ public class PortfolioResDto {
     private long memberNum;
 
     private List<PortfolioItemResDto> portfolioItems;
-//    private PortfolioPortionDto portion;
+    private PortfolioPortionDto portion;
 
     public static PortfolioResDto of(PortfolioVO vo) {
         return vo == null ? null : PortfolioResDto.builder()

--- a/src/main/java/com/be/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/be/portfolio/service/PortfolioService.java
@@ -21,5 +21,5 @@ public interface PortfolioService {
 
     void deletePortfolio(int id);
     PortfolioReqDto calculatePortfolio(PortfolioReqDto portfolioReqDto, List<Object> portfolioItems);
-//    PortfolioPortionDto calculatePortion(List<PortfolioItemResDto> portfolioItems);
+    PortfolioPortionDto calculatePortion(List<PortfolioItemResDto> portfolioItems);
 }


### PR DESCRIPTION
1. calculatePortion 기능 추가(포트폴리오 상품별 총 투자금액 계산 기능)
* 포트폴리오 내 상품 타입 별(null은 주식) 총 투자금액을 portfolioPortiondto 객체로 포트폴리오 객체 내에 저장

2.portfolioitem 테이블 변경
* productType column 추가