### PR TITLE
feat: 금융상품 정렬 기능 백엔드 로직 추가

### DIFF
--- a/src/main/java/com/be/finance/controller/BondProductController.java
+++ b/src/main/java/com/be/finance/controller/BondProductController.java
@@ -42,9 +42,11 @@ public class BondProductController {
     @GetMapping("/list")
     public ResponseEntity<Map<String, Object>> getBondProductsList(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int pageSize) {
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(defaultValue = "bondIsurNm") String sortField, // 정렬 필드 추가
+            @RequestParam(defaultValue = "asc") String sortOrder) {
         try {
-            Map<String, Object> bondProducts = bondProductService.getBondProductsList(page, pageSize);
+            Map<String, Object> bondProducts = bondProductService.getBondProductsList(page, pageSize, sortField, sortOrder);
             System.out.println("성공");
             return ResponseEntity.ok(bondProducts);
         } catch (Exception e) {

--- a/src/main/java/com/be/finance/controller/FundProductController.java
+++ b/src/main/java/com/be/finance/controller/FundProductController.java
@@ -54,9 +54,17 @@ public class FundProductController {
     @GetMapping("/list")
     public ResponseEntity<Map<String, Object>> getFundProductsList(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int pageSize) {
-        Map<String, Object> fundProducts = fundProductService.getFundProductsList(page, pageSize);
-        return ResponseEntity.ok(fundProducts);
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(defaultValue = "company_nm") String sortField,
+            @RequestParam(defaultValue = "asc") String sortOrder) {
+        try {
+            Map<String, Object> fundProducts = fundProductService.getFundProductsList(page, pageSize, sortField, sortOrder);
+            System.out.println("성공");
+            return ResponseEntity.ok(fundProducts);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // 검색어 기반 펀드 상품 검색

--- a/src/main/java/com/be/finance/controller/SavingProductController.java
+++ b/src/main/java/com/be/finance/controller/SavingProductController.java
@@ -36,16 +36,20 @@ public class SavingProductController {
     @GetMapping("/deposit")
     public Map<String, Object> getDepositProducts(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int pageSize) {
-        return savingProductService.getDepositProducts(page, pageSize);
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(defaultValue = "kor_co_nm") String sortField,
+            @RequestParam(defaultValue = "asc") String sortOrder) {
+        return savingProductService.getDepositProducts(page, pageSize, sortField, sortOrder);
     }
 
     // 적금 리스트 조회 API
     @GetMapping("/saving")
     public Map<String, Object> getSavingProducts(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int pageSize) {
-        return savingProductService.getSavingProducts(page, pageSize);
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(defaultValue = "kor_co_nm") String sortField,
+            @RequestParam(defaultValue = "asc") String sortOrder) {
+        return savingProductService.getSavingProducts(page, pageSize, sortField, sortOrder);
     }
 
     // 예금 상품 검색

--- a/src/main/java/com/be/finance/mapper/BondProductMapper.java
+++ b/src/main/java/com/be/finance/mapper/BondProductMapper.java
@@ -12,8 +12,8 @@ public interface BondProductMapper {
     void insertBondProduct(BondProductVO bondProductVO);
     void updateBondProductPrice(BondProductVO bondProductVO);
 
-    // 전체 채권 리스트 조회
-    List<BondProductVO> getBondProductsList();
+    // 전체 채권 리스트 조회 (정렬 추가)
+    List<BondProductVO> getBondProductsList(@Param("sortField") String sortField, @Param("sortOrder") String sortOrder);
 
     // 채권 검색 리스트 조회
     List<BondProductVO> searchBondProducts(@Param("keyword") String keyword);

--- a/src/main/java/com/be/finance/mapper/FundProductMapper.java
+++ b/src/main/java/com/be/finance/mapper/FundProductMapper.java
@@ -12,7 +12,7 @@ public interface FundProductMapper {
     void insertFundProduct(FundProductVO fundProductVO);
 
     // 펀드 리스트 조회
-    List<FundProductVO> getFundProductsList();
+    List<FundProductVO> getFundProductsList(@Param("sortField") String sortField, @Param("sortOrder") String sortOrder);
 
     // 펀드 검색 리스트 조회
     List<FundProductVO> searchFundProducts(@Param("keyword") String keyword);

--- a/src/main/java/com/be/finance/mapper/SavingProductMapper.java
+++ b/src/main/java/com/be/finance/mapper/SavingProductMapper.java
@@ -18,13 +18,13 @@ public interface SavingProductMapper {
     void insertSavingProductRate(SavingProductRatesVO rate);
 
     // 예금 데이터 리스트 조회
-    List<SavingProductVO> getDepositProducts();
+    List<SavingProductVO> getDepositProducts(@Param("sortField") String sortField, @Param("sortOrder") String sortOrder);
 
     // 예금 기간별 수익률 리스트 조회
     List<SavingProductRatesVO> getDepositRates();
 
     // 적금 데이터 리스트 조회
-    List<SavingProductVO> getSavingProducts();
+    List<SavingProductVO> getSavingProducts(@Param("sortField") String sortField, @Param("sortOrder") String sortOrder);
 
     // 적금 기간별 수익률 리스트 조회
     List<SavingProductRatesVO> getSavingRates(List<SavingProductVO> productList);

--- a/src/main/java/com/be/finance/service/BondProductService.java
+++ b/src/main/java/com/be/finance/service/BondProductService.java
@@ -258,8 +258,8 @@ public class BondProductService {
     }
 
     // 전체 채권 리스트 조회
-    public Map<String, Object> getBondProductsList(int page, int pageSize) {
-        List<BondProductVO> bondproducts = bondProductMapper.getBondProductsList();
+    public Map<String, Object> getBondProductsList(int page, int pageSize, String sortField, String sortOrder) {
+        List<BondProductVO> bondproducts = bondProductMapper.getBondProductsList(sortField, sortOrder);
         return paginationService.paginate(bondproducts, page, pageSize);
     }
 

--- a/src/main/java/com/be/finance/service/FundProductService.java
+++ b/src/main/java/com/be/finance/service/FundProductService.java
@@ -72,8 +72,8 @@ public class FundProductService {
     }
 
     // 펀드 리스트 가져오기
-    public Map<String, Object> getFundProductsList(int page, int pageSize) {
-        List<FundProductVO> fundProducts = fundProductMapper.getFundProductsList();
+    public Map<String, Object> getFundProductsList(int page, int pageSize, String sortField, String sortOrder) {
+        List<FundProductVO> fundProducts = fundProductMapper.getFundProductsList(sortField, sortOrder);
         return paginationService.paginate(fundProducts, page, pageSize);
     }
 

--- a/src/main/java/com/be/finance/service/SavingProductService.java
+++ b/src/main/java/com/be/finance/service/SavingProductService.java
@@ -196,9 +196,9 @@ public class SavingProductService {
     }
 
     // 예금 리스트
-    public Map<String, Object> getDepositProducts(int page, int pageSize) {
+    public Map<String, Object> getDepositProducts(int page, int pageSize, String sortField, String sortOrder) {
         // 예금 상품 조회
-        List<SavingProductVO> depositProducts = savingProductMapper.getDepositProducts();
+        List<SavingProductVO> depositProducts = savingProductMapper.getDepositProducts(sortField, sortOrder);
 
         Map<String, Object> paginatedProducts = paginationService.paginate(depositProducts, page, pageSize);
 
@@ -255,9 +255,9 @@ public class SavingProductService {
     }
 
     // 전체 적금 리스트
-    public Map<String, Object> getSavingProducts(int page, int pageSize) {
+    public Map<String, Object> getSavingProducts(int page, int pageSize, String sortField, String sortOrder) {
         // 적금 상품 조회
-        List<SavingProductVO> savingProducts = savingProductMapper.getSavingProducts();
+        List<SavingProductVO> savingProducts = savingProductMapper.getSavingProducts(sortField, sortOrder);
 
         Map<String, Object> paginatedProducts = paginationService.paginate(savingProducts, page, pageSize);
 

--- a/src/main/resources/mapper/BondProductMapper.xml
+++ b/src/main/resources/mapper/BondProductMapper.xml
@@ -66,6 +66,21 @@
     <!-- 채권 상품 조회 -->
     <select id="getBondProductsList" resultType="com.be.finance.domain.BondProductVO">
         SELECT * FROM BondProduct
+        <if test="sortField != null and sortOrder != null">
+            ORDER BY
+                <choose>
+                    <when test="sortField == 'bondIsurNm'">bondIsurNm</when>
+                    <when test="sortField == 'isinCdNm'">isinCdNm</when>
+                    <when test="sortField == 'bondIssuDt'">bondIssuDt</when>
+                    <when test="sortField == 'bondSrfcInrt'">bondSrfcInrt</when>
+                    <otherwise>productId</otherwise>
+                </choose>
+                <choose>
+                    <when test="sortOrder == 'asc'">ASC</when>
+                    <when test="sortOrder == 'desc'">DESC</when>
+                    <otherwise>ASC</otherwise> <!-- 기본 정렬 순서 -->
+                </choose>
+        </if>
     </select>
 
     <!-- 채권 상품 검색 -->

--- a/src/main/resources/mapper/FundProductMapper.xml
+++ b/src/main/resources/mapper/FundProductMapper.xml
@@ -16,6 +16,22 @@
     <!-- 펀드 상품 조회 -->
     <select id="getFundProductsList" resultType="com.be.finance.domain.FundProductVO">
         SELECT * FROM FundProduct
+        <if test="sortField != null and sortOrder != null">
+            ORDER BY
+                <choose>
+                    <when test="sortField == 'company_nm'">company_nm</when>
+                    <when test="sortField == 'product_nm'">product_nm</when>
+                    <when test="sortField == 'fund_type'">fund_type</when>
+                    <when test="sortField == 'risk_level'">RiskLevel</when>
+                    <when test="sortField == 'yield_12'">yield_12</when>
+                    <otherwise>productId</otherwise>
+                </choose>
+                <choose>
+                    <when test="sortOrder == 'asc'">ASC</when>
+                    <when test="sortOrder == 'desc'">DESC</when>
+                    <otherwise>ASC</otherwise>
+                </choose>
+        </if>
     </select>
 
     <!-- 검색어 기반펀드 상품 조회 -->

--- a/src/main/resources/mapper/SavingProductMapper.xml
+++ b/src/main/resources/mapper/SavingProductMapper.xml
@@ -35,14 +35,40 @@
     <select id="getDepositProducts" resultType="com.be.finance.domain.SavingProductVO">
         SELECT *
         FROM SavingsProduct
-        WHERE fin_prdt_nm LIKE '%예금%';
+        WHERE fin_prdt_nm LIKE '%예금%'
+        <if test="sortField != null and sortOrder != null">
+            ORDER BY
+                <choose>
+                    <when test="sortField == 'kor_co_nm'">kor_co_nm</when>
+                    <when test="sortField == 'fin_prdt_nm'">fin_prdt_nm</when>
+                    <otherwise>productId</otherwise>
+                </choose>
+                <choose>
+                    <when test="sortOrder == 'asc'">ASC</when>
+                    <when test="sortOrder == 'desc'">DESC</when>
+                    <otherwise>ASC</otherwise>
+                </choose>
+        </if>
     </select>
 
     <!-- 전체 적금 상품 조회 -->
     <select id="getSavingProducts" resultType="com.be.finance.domain.SavingProductVO">
         SELECT *
         FROM SavingsProduct
-        WHERE fin_prdt_nm LIKE '%적금%';
+        WHERE fin_prdt_nm LIKE '%적금%'
+        <if test="sortField != null and sortOrder != null">
+            ORDER BY
+                <choose>
+                    <when test="sortField == 'kor_co_nm'">kor_co_nm</when>
+                    <when test="sortField == 'fin_prdt_nm'">fin_prdt_nm</when>
+                    <otherwise>productId</otherwise>
+                </choose>
+                <choose>
+                    <when test="sortOrder == 'asc'">ASC</when>
+                    <when test="sortOrder == 'desc'">DESC</when>
+                    <otherwise>ASC</otherwise>
+                </choose>
+        </if>
     </select>
 
     <!-- 예금 상품 금리 정보 조회 (rsrv_type IS NULL) -->


### PR DESCRIPTION
금융 상품 정렬 기능 백엔드 로직 추가
1. sortField, sortOrder 쿼리 파라미터 추가
2. sortField는 각 금융 상품 별 DB에 저장된 컬럼명 사용
3. sortOrder는 'asc', 'desc' 중 하나 선택
(예시로, 예금의 금융회사 첫 클릭 시 sortField = 'kor_co_nm', sortOrder = 'asc' 정렬 되게 설정, 한번 더 클릭시 금융 회사 기준으로 내림차순 정렬로 변경)
API 호출 방식은 달라진 게 없고 프론트에서 쿼리 파라미터만 추가시켜주시면 됩니다.